### PR TITLE
configure tox

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,5 @@
+[tox]
+envlist=py36
+[testenv]
+deps=pytest
+commands=pytest


### PR DESCRIPTION
tox runs with this minimalist tox.ini file -- but only for python 3.6

closes #31