### PR TITLE
Semi supervised

### DIFF
--- a/examples/scVI-dev.ipynb
+++ b/examples/scVI-dev.ipynb
@@ -499,8 +499,8 @@
     "                         collate_fn = gene_dataset.collate_fn)\n",
     "\n",
     "latent, batch_indices, labels = get_latent(vae,data_loader)\n",
-    "latent=latent.cpu().numpy()\n",
-    "labels = np.concatenate(labels.cpu().numpy())\n",
+    "latent=latent\n",
+    "labels = np.concatenate(labels)\n",
     "\n",
     "if latent.shape[1] != 2:\n",
     "    latent = TSNE().fit_transform(latent)\n"
@@ -1284,7 +1284,7 @@
     "\n",
     "data_loader = DataLoader(gene_dataset, batch_size=128, pin_memory=use_cuda,shuffle=False,collate_fn = gene_dataset.collate_fn)\n",
     "latent, batch_indices, labels = get_latent(vae,data_loader)\n",
-    "latent=latent.cpu().numpy()\n"
+    "latent=latent"
    ]
   },
   {
@@ -1309,7 +1309,7 @@
    ],
    "source": [
     "latent, batch_indices, labels = get_latent(vae, data_loader_train)\n",
-    "print(\"Entropy batch mixing :\", entropy_batch_mixing(latent.cpu().numpy(), batch_indices.cpu().numpy()))\n"
+    "print(\"Entropy batch mixing :\", entropy_batch_mixing(latent, batch_indices))"
    ]
   },
   {

--- a/examples/scVI-dev.ipynb
+++ b/examples/scVI-dev.ipynb
@@ -44,7 +44,7 @@
     "from scvi.metrics.visualization import show_t_sne\n",
     "\n",
     "from scvi.models import VAE, SVAEC\n",
-    "from scvi.models.modules import Classifier\n",
+    "from scvi.models.classifier import Classifier\n",
     "\n",
     "from scvi.train import train, train_classifier\n",
     "\n",

--- a/examples/scVI-semi-supervised.ipynb
+++ b/examples/scVI-semi-supervised.ipynb
@@ -1,0 +1,249 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### A semi-supervised framework for the annotation problem\n",
+    "\n",
+    "**NB**: please refer to the scVI-dev notebook for introduction of the scVI package.\n",
+    "\n",
+    "In this notebook, we investigate how semi-supervised learning combined with the probabilistic modelling of latent variables in scVI can help address the annotation problem.\n",
+    "\n",
+    "The annotation problem consists in labelling cells, ie. **inferring their cell types**, knowing only a part of the labels."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "/home/ubuntu/scVI\n"
+     ]
+    }
+   ],
+   "source": [
+    "cd .."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/home/ubuntu/anaconda3/lib/python3.6/site-packages/matplotlib/__init__.py:1067: UserWarning: Duplicate key in file \"/home/ubuntu/.config/matplotlib/matplotlibrc\", line #2\n",
+      "  (fname, cnt))\n",
+      "/home/ubuntu/anaconda3/lib/python3.6/site-packages/matplotlib/__init__.py:1067: UserWarning: Duplicate key in file \"/home/ubuntu/.config/matplotlib/matplotlibrc\", line #3\n",
+      "  (fname, cnt))\n",
+      "/home/ubuntu/anaconda3/lib/python3.6/site-packages/h5py/__init__.py:36: FutureWarning: Conversion of the second argument of issubdtype from `float` to `np.floating` is deprecated. In future, it will be treated as `np.float64 == np.dtype(float).type`.\n",
+      "  from ._conv import register_converters as _register_converters\n"
+     ]
+    }
+   ],
+   "source": [
+    "from scvi.dataset import load_datasets\n",
+    "from scvi.models import SVAEC\n",
+    "from scvi.dataset.utils import get_data_loaders\n",
+    "from scvi.train import train_semi_supervised_alternately, train_semi_supervised_jointly\n",
+    "from scvi.metrics.classification import compute_accuracy_svc, compute_accuracy_rf\n",
+    "from scvi.dataset.utils import get_raw_data"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Pickle for :  ../scVI-dev/data/cortex-tmp\n",
+      "Number of labelled samples :  70\n",
+      "Labels and their proportions:  (array([0, 1, 2, 3, 4, 5, 6]), array([10, 10, 10, 10, 10, 10, 10]))\n"
+     ]
+    }
+   ],
+   "source": [
+    "gene_dataset = load_datasets('cortex')\n",
+    "\n",
+    "use_batches=False\n",
+    "use_cuda=True\n",
+    "data_loader_all, data_loader_labelled, data_loader_unlabelled = get_data_loaders(gene_dataset, 10, \n",
+    "                                                                                 batch_size=128, pin_memory=use_cuda)\n",
+    "\n",
+    "# Sanity checks\n",
+    "print(\"Number of labelled samples : \",len(data_loader_labelled.sampler.indices))\n",
+    "print(\"Labels and their proportions: \",np.unique(gene_dataset.labels[data_loader_labelled.sampler.indices], return_counts=True))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": []
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We instantiate the SVAEC model and train it over 200 epochs. Only labels from the `data_loader_labelled` will be used, but to cross validate the results, the labels of `data_loader_unlabelled` will is used at test time. The accuracy of the `unlabelled` dataset reaches 93% here at the end of training."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "EPOCH [0/200]: \n",
+      "LL labelled is: 29015.107143\n",
+      "Accuracy labelled is: 0.128571\n",
+      "LL unlabelled is: 34288.181346\n",
+      "Accuracy unlabelled is: 0.056899\n",
+      "EPOCH [100/200]: \n",
+      "LL labelled is: 1282.663281\n",
+      "Accuracy labelled is: 1.000000\n",
+      "LL unlabelled is: 1356.807842\n",
+      "Accuracy unlabelled is: 0.935605\n",
+      "EPOCH [200/200]: \n",
+      "LL labelled is: 1248.819085\n",
+      "Accuracy labelled is: 1.000000\n",
+      "LL unlabelled is: 1298.822759\n",
+      "Accuracy unlabelled is: 0.937308\n",
+      "Total runtime for 201 epochs is: 80.45947861671448 seconds for a mean per epoch runtime of 0.4002959135159924 seconds.\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "<scvi.metrics.stats.Stats at 0x7fcab3b67828>"
+      ]
+     },
+     "execution_count": 11,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "svaec = SVAEC(gene_dataset.nb_genes, n_batch=gene_dataset.n_batches * use_batches, n_labels=gene_dataset.n_labels,\n",
+    "            use_cuda=use_cuda)\n",
+    "train_semi_supervised_jointly(svaec, data_loader_all, data_loader_labelled, data_loader_unlabelled, n_epochs=200, record_freq=100)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Benchmarking against other algorithms\n",
+    "\n",
+    "We can compare ourselves against the random forest and SVM algorithms, where we do grid search with 3-fold cross validation to find the best hyperparameters of these algorithms. This is automatically performed through the functions **`compute_accuracy_svc`** and **`compute_accuracy_rf`**.\n",
+    "\n",
+    "These functions should be given as input the numpy array corresponding to the equivalent dataloaders, which is the purpose of the **`get_raw_data`** method from `scvi.dataset.utils`.\n",
+    "\n",
+    "The format of the result is an Accuracy named tuple object giving higher granularity information about the accuracy ie, with attributes:\n",
+    "\n",
+    "- **unweighted**: the standard definition of accuracy\n",
+    "\n",
+    "- **weighted**: we might give the same weight to all classes in the final accuracy results. Informative only if the dataset is unbalanced.\n",
+    "\n",
+    "- **worst**: the worst accuracy score for the classes\n",
+    "\n",
+    "- **accuracy_classes** : give the detail of the accuracy per classes\n",
+    "\n",
+    "\n",
+    "1 - Load the data"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "(data_train, labels_train), (data_test, labels_test) = get_raw_data(data_loader_labelled, data_loader_unlabelled)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "2 - Compute the accuracy score for svc"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Accuracy(unweighted=0.8701873935264055, weighted=0.8465908861701248, worst=0.7223650385604113, accuracy_classes=[0.794392523364486, 0.9066666666666666, 0.8857142857142857, 0.7954545454545454, 0.9345679012345679, 0.8869752421959096, 0.7223650385604113])\n"
+     ]
+    }
+   ],
+   "source": [
+    "accuracy_train , accuracy_test = compute_accuracy_svc(data_train, labels_train,data_test, labels_test)\n",
+    "print(accuracy_test)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "3 - Compute the accuracy score for rf"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Accuracy(unweighted=0.9281090289608177, weighted=0.8978442470701393, worst=0.7954545454545454, accuracy_classes=[0.8738317757009346, 0.9022222222222223, 0.9857142857142858, 0.7954545454545454, 0.9604938271604938, 0.9677072120559742, 0.7994858611825193])\n"
+     ]
+    }
+   ],
+   "source": [
+    "accuracy_train , accuracy_test = compute_accuracy_rf(data_train, labels_train,data_test, labels_test)\n",
+    "print(accuracy_test)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.6.4"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/examples/scVI-semi-supervised.ipynb
+++ b/examples/scVI-semi-supervised.ipynb
@@ -34,32 +34,20 @@
    "cell_type": "code",
    "execution_count": 2,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/home/ubuntu/anaconda3/lib/python3.6/site-packages/matplotlib/__init__.py:1067: UserWarning: Duplicate key in file \"/home/ubuntu/.config/matplotlib/matplotlibrc\", line #2\n",
-      "  (fname, cnt))\n",
-      "/home/ubuntu/anaconda3/lib/python3.6/site-packages/matplotlib/__init__.py:1067: UserWarning: Duplicate key in file \"/home/ubuntu/.config/matplotlib/matplotlibrc\", line #3\n",
-      "  (fname, cnt))\n",
-      "/home/ubuntu/anaconda3/lib/python3.6/site-packages/h5py/__init__.py:36: FutureWarning: Conversion of the second argument of issubdtype from `float` to `np.floating` is deprecated. In future, it will be treated as `np.float64 == np.dtype(float).type`.\n",
-      "  from ._conv import register_converters as _register_converters\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "from scvi.dataset import load_datasets\n",
     "from scvi.models import SVAEC\n",
     "from scvi.dataset.utils import get_data_loaders\n",
     "from scvi.train import train_semi_supervised_alternately, train_semi_supervised_jointly\n",
     "from scvi.metrics.classification import compute_accuracy_svc, compute_accuracy_rf\n",
-    "from scvi.dataset.utils import get_raw_data"
+    "from scvi.dataset.utils import get_raw_data\n",
+    "import numpy as np"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 3,
    "metadata": {},
    "outputs": [
     {
@@ -99,7 +87,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 4,
    "metadata": {},
    "outputs": [
     {
@@ -107,30 +95,30 @@
      "output_type": "stream",
      "text": [
       "EPOCH [0/200]: \n",
-      "LL labelled is: 29015.107143\n",
-      "Accuracy labelled is: 0.128571\n",
-      "LL unlabelled is: 34288.181346\n",
-      "Accuracy unlabelled is: 0.056899\n",
+      "LL labelled is: 32302.121429\n",
+      "Accuracy labelled is: 0.014286\n",
+      "LL unlabelled is: 38213.741227\n",
+      "Accuracy unlabelled is: 0.026576\n",
       "EPOCH [100/200]: \n",
-      "LL labelled is: 1282.663281\n",
+      "LL labelled is: 1274.317076\n",
       "Accuracy labelled is: 1.000000\n",
-      "LL unlabelled is: 1356.807842\n",
-      "Accuracy unlabelled is: 0.935605\n",
+      "LL unlabelled is: 1367.440013\n",
+      "Accuracy unlabelled is: 0.944804\n",
       "EPOCH [200/200]: \n",
-      "LL labelled is: 1248.819085\n",
+      "LL labelled is: 1193.052344\n",
       "Accuracy labelled is: 1.000000\n",
-      "LL unlabelled is: 1298.822759\n",
-      "Accuracy unlabelled is: 0.937308\n",
-      "Total runtime for 201 epochs is: 80.45947861671448 seconds for a mean per epoch runtime of 0.4002959135159924 seconds.\n"
+      "LL unlabelled is: 1259.477050\n",
+      "Accuracy unlabelled is: 0.945826\n",
+      "Total runtime for 201 epochs is: 80.55557942390442 seconds for a mean per epoch runtime of 0.4007740269845991 seconds.\n"
      ]
     },
     {
      "data": {
       "text/plain": [
-       "<scvi.metrics.stats.Stats at 0x7fcab3b67828>"
+       "<scvi.metrics.stats.Stats at 0x7f41d657ceb8>"
       ]
      },
-     "execution_count": 11,
+     "execution_count": 4,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -167,7 +155,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 5,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -183,7 +171,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 6,
    "metadata": {},
    "outputs": [
     {
@@ -208,7 +196,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 7,
    "metadata": {},
    "outputs": [
     {

--- a/scvi/benchmark.py
+++ b/scvi/benchmark.py
@@ -5,8 +5,9 @@ from torch.utils.data import DataLoader
 from torch.utils.data.sampler import SubsetRandomSampler
 
 from scvi.dataset import CortexDataset, load_datasets
-from scvi.dataset.utils import get_data_loaders
+from scvi.dataset.utils import get_data_loaders, get_raw_data
 from scvi.metrics.adapt_encoder import adapt_encoder
+from scvi.metrics.classification import compute_accuracy_rf, compute_accuracy_svc
 from scvi.metrics.clustering import entropy_batch_mixing, get_latent
 from scvi.metrics.differential_expression import get_statistics
 from scvi.metrics.imputation import imputation
@@ -74,6 +75,14 @@ def run_benchmarks_classification(dataset_name, n_latent=10, n_epochs=10, n_epoc
                                                                                      batch_size=128,
                                                                                      pin_memory=use_cuda)
     # Now we try out the different models and compare the classification accuracy
+
+
+    (data_train, labels_train), (data_test, labels_test) = get_raw_data(data_loader_labelled, data_loader_unlabelled)
+    accuracy_train_svc, accuracy_test_svc = compute_accuracy_svc(data_train, labels_train, data_test, labels_test,
+                                                                 unit_test=True)
+    accuracy_train_rf, accuracy_test_rf = compute_accuracy_rf(data_train, labels_train, data_test, labels_test,
+                                                              unit_test=True)
+
 
     # ========== The M1 model ===========
     print("Trying M1 model")

--- a/scvi/benchmark.py
+++ b/scvi/benchmark.py
@@ -5,14 +5,15 @@ from torch.utils.data import DataLoader
 from torch.utils.data.sampler import SubsetRandomSampler
 
 from scvi.dataset import CortexDataset, load_datasets
+from scvi.dataset.utils import get_data_loaders
 from scvi.metrics.adapt_encoder import adapt_encoder
 from scvi.metrics.clustering import entropy_batch_mixing, get_latent
 from scvi.metrics.differential_expression import get_statistics
 from scvi.metrics.imputation import imputation
 from scvi.metrics.visualization import show_t_sne
 from scvi.models import VAE, SVAEC
-from scvi.models.modules import Classifier
-from scvi.train import train, train_classifier, train_semi_supervised
+from scvi.models.classifier import Classifier
+from scvi.train import train, train_classifier, train_semi_supervised_jointly, train_semi_supervised_alternatively
 
 
 def run_benchmarks(dataset_name, model=VAE, n_epochs=1000, lr=1e-3, use_batches=False, use_cuda=True,
@@ -53,9 +54,9 @@ def run_benchmarks(dataset_name, model=VAE, n_epochs=1000, lr=1e-3, use_batches=
     # - batch mixing
     if gene_dataset.n_batches == 2:
         latent, batch_indices, labels = get_latent(vae, data_loader_train)
-        print("Entropy batch mixing :", entropy_batch_mixing(latent.cpu().numpy(), batch_indices.cpu().numpy()))
+        print("Entropy batch mixing :", entropy_batch_mixing(latent, batch_indices))
         if show_batch_mixing:
-            show_t_sne(latent.cpu().numpy(), np.array([batch[0] for batch in batch_indices.cpu().numpy()]))
+            show_t_sne(latent, np.array([batch[0] for batch in batch_indices]))
 
     # - differential expression
     if type(gene_dataset) == CortexDataset:
@@ -67,20 +68,11 @@ def run_benchmarks_classification(dataset_name, n_latent=10, n_epochs=10, n_epoc
                                   use_batches=False, use_cuda=True, tt_split=0.9):
     gene_dataset = load_datasets(dataset_name)
     fig, axes = plt.subplots(1, 2, sharey=True, figsize=(12, 5))
-
     alpha = 100  # in Kingma, 0.1 * len(gene_dataset), but pb when : len(gene_dataset) >> 1
 
-    # Create the dataset
-    example_indices = np.random.permutation(len(gene_dataset))
-    tt_split = int(tt_split * len(gene_dataset))  # 90%/10% train/test split
-
-    data_loader_train = DataLoader(gene_dataset, batch_size=128, pin_memory=use_cuda,
-                                   sampler=SubsetRandomSampler(example_indices[:tt_split]),
-                                   collate_fn=gene_dataset.collate_fn)
-    data_loader_test = DataLoader(gene_dataset, batch_size=128, pin_memory=use_cuda,
-                                  sampler=SubsetRandomSampler(example_indices[tt_split:]),
-                                  collate_fn=gene_dataset.collate_fn)
-
+    data_loader_all, data_loader_labelled, data_loader_unlabelled = get_data_loaders(gene_dataset, 10,
+                                                                                     batch_size=128,
+                                                                                     pin_memory=use_cuda)
     # Now we try out the different models and compare the classification accuracy
 
     # ========== The M1 model ===========
@@ -88,13 +80,15 @@ def run_benchmarks_classification(dataset_name, n_latent=10, n_epochs=10, n_epoc
     vae = VAE(gene_dataset.nb_genes, n_latent=n_latent,
               n_batch=gene_dataset.n_batches * use_batches, use_cuda=use_cuda,
               n_labels=gene_dataset.n_labels)
-    train_semi_supervised(vae, data_loader_train, data_loader_test, n_epochs=n_epochs, lr=lr)
+    train_semi_supervised_jointly(vae, data_loader_all, data_loader_labelled, data_loader_unlabelled,
+                                  n_epochs=n_epochs, lr=lr)
 
     # Then we train a classifier on the latent space
     cls = Classifier(n_input=n_latent, n_labels=gene_dataset.n_labels, n_layers=3, use_cuda=use_cuda)
     for param in vae.z_encoder.parameters():
         param.requires_grad = False
-    cls_stats = train_classifier(vae, cls, data_loader_train, data_loader_test, n_epochs=n_epochs_classifier, lr=lr)
+    cls_stats = train_classifier(vae, cls, data_loader_labelled, data_loader_unlabelled, n_epochs=n_epochs_classifier,
+                                 lr=lr)
 
     axes[0].plot(cls_stats.history["Accuracy_train"], label='classifier')
     axes[1].plot(cls_stats.history["Accuracy_test"])
@@ -110,8 +104,8 @@ def run_benchmarks_classification(dataset_name, n_latent=10, n_epochs=10, n_epoc
     svaec.z_encoder.load_state_dict(vae.z_encoder.state_dict())
     for param in svaec.z_encoder.parameters():
         param.requires_grad = False
-    stats = train_semi_supervised(svaec, data_loader_train, data_loader_test, n_epochs=n_epochs, lr=lr,
-                                  classification_ratio=alpha)
+    stats = train_semi_supervised_jointly(svaec, data_loader_all, data_loader_labelled, data_loader_unlabelled,
+                                          n_epochs=n_epochs, lr=lr, classification_ratio=alpha)
 
     # We don't train the first z encoder in this procedure
     axes[0].plot(stats.history["Accuracy_train"], label='M1+M2 (frozen)')
@@ -120,10 +114,16 @@ def run_benchmarks_classification(dataset_name, n_latent=10, n_epochs=10, n_epoc
     # ========== The M1+M2 model trained jointly ===========
     print("Trying out M1+M2 optimized jointly")
     svaec = SVAEC(gene_dataset.nb_genes, n_labels=gene_dataset.n_labels, y_prior=prior, n_latent=n_latent,
-                  use_cuda=use_cuda)
+                  use_cuda=use_cuda, logreg_classifier=False)
 
-    stats = train_semi_supervised(svaec, data_loader_train, data_loader_test, n_epochs=n_epochs, lr=lr,
-                                  classification_ratio=alpha)
+    stats = train_semi_supervised_jointly(svaec, data_loader_all, data_loader_labelled, data_loader_unlabelled,
+                                          n_epochs=n_epochs, lr=lr, classification_ratio=100, record_freq=10)
+
+    svaec = SVAEC(gene_dataset.nb_genes, n_labels=gene_dataset.n_labels, y_prior=prior, n_latent=n_latent,
+                  use_cuda=use_cuda, logreg_classifier=True)
+
+    stats = train_semi_supervised_alternatively(svaec, data_loader_all, data_loader_labelled, data_loader_unlabelled,
+                                                n_epochs=n_epochs, lr=lr, record_freq=10, lr_classification=0.05)
 
     axes[0].plot(stats.history["Accuracy_train"], label='M1+M2 (train all)')
     axes[1].plot(stats.history["Accuracy_test"])
@@ -132,7 +132,8 @@ def run_benchmarks_classification(dataset_name, n_latent=10, n_epochs=10, n_epoc
     print("Trying to classify on M1+M2's z1 latent space")
     cls = Classifier(n_input=n_latent, n_labels=gene_dataset.n_labels, n_layers=3, use_cuda=use_cuda)
 
-    stats = train_classifier(svaec, cls, data_loader_train, data_loader_test, n_epochs=n_epochs_classifier, lr=lr)
+    stats = train_classifier(svaec, cls, data_loader_labelled, data_loader_unlabelled, n_epochs=n_epochs_classifier,
+                             lr=lr)
 
     axes[0].plot(stats.history["Accuracy_train"], label='M1+M2+classifier')
     axes[1].plot(stats.history["Accuracy_test"])

--- a/scvi/benchmark.py
+++ b/scvi/benchmark.py
@@ -76,13 +76,11 @@ def run_benchmarks_classification(dataset_name, n_latent=10, n_epochs=10, n_epoc
                                                                                      pin_memory=use_cuda)
     # Now we try out the different models and compare the classification accuracy
 
-
     (data_train, labels_train), (data_test, labels_test) = get_raw_data(data_loader_labelled, data_loader_unlabelled)
     accuracy_train_svc, accuracy_test_svc = compute_accuracy_svc(data_train, labels_train, data_test, labels_test,
                                                                  unit_test=True)
     accuracy_train_rf, accuracy_test_rf = compute_accuracy_rf(data_train, labels_train, data_test, labels_test,
                                                               unit_test=True)
-
 
     # ========== The M1 model ===========
     print("Trying M1 model")

--- a/scvi/benchmark.py
+++ b/scvi/benchmark.py
@@ -13,7 +13,7 @@ from scvi.metrics.imputation import imputation
 from scvi.metrics.visualization import show_t_sne
 from scvi.models import VAE, SVAEC
 from scvi.models.classifier import Classifier
-from scvi.train import train, train_classifier, train_semi_supervised_jointly, train_semi_supervised_alternatively
+from scvi.train import train, train_classifier, train_semi_supervised_jointly, train_semi_supervised_alternately
 
 
 def run_benchmarks(dataset_name, model=VAE, n_epochs=1000, lr=1e-3, use_batches=False, use_cuda=True,
@@ -122,8 +122,8 @@ def run_benchmarks_classification(dataset_name, n_latent=10, n_epochs=10, n_epoc
     svaec = SVAEC(gene_dataset.nb_genes, n_labels=gene_dataset.n_labels, y_prior=prior, n_latent=n_latent,
                   use_cuda=use_cuda, logreg_classifier=True)
 
-    stats = train_semi_supervised_alternatively(svaec, data_loader_all, data_loader_labelled, data_loader_unlabelled,
-                                                n_epochs=n_epochs, lr=lr, record_freq=10, lr_classification=0.05)
+    stats = train_semi_supervised_alternately(svaec, data_loader_all, data_loader_labelled, data_loader_unlabelled,
+                                              n_epochs=n_epochs, lr=lr, record_freq=10, lr_classification=0.05)
 
     axes[0].plot(stats.history["Accuracy_train"], label='M1+M2 (train all)')
     axes[1].plot(stats.history["Accuracy_test"])

--- a/scvi/dataset/utils.py
+++ b/scvi/dataset/utils.py
@@ -1,0 +1,42 @@
+import numpy as np
+from torch.utils.data import DataLoader
+from torch.utils.data.sampler import SubsetRandomSampler
+
+
+def get_indices(labels, n_labelled_samples_per_class_array):
+    labels = np.array(labels).ravel()
+    np.random.seed(0)
+    permutation_idx = np.random.permutation(len(labels))
+    labels = labels[permutation_idx]
+    indices = []
+    current_nbrs = np.zeros(len(n_labelled_samples_per_class_array))
+    for idx, (label) in enumerate(labels):
+        label = int(label)
+        if current_nbrs[label] < n_labelled_samples_per_class_array[label]:
+            indices.insert(0, idx)
+            current_nbrs[label] += 1
+        else:
+            indices.append(idx)
+    indices = np.array(indices)
+    total_labelled = sum(n_labelled_samples_per_class_array)
+    return permutation_idx[indices[:total_labelled]], permutation_idx[indices[total_labelled:]]
+
+
+def get_data_loaders(gene_dataset, n_labelled_samples_per_class, **kwargs_data_loader):
+    """
+    For use in train_semi_supervised
+    Get labelled/unlabelled/all data_loaders from gene_dataset
+    :param gene_dataset: the dataset to consider
+    :param n_labelled_samples_per_class: number of labelled samples per class
+    :param kwargs_data_loader: any additional keyword arguments to pass to the dataloaders
+    :return: data_loader_labelled/data_loader_unlabelled/data_loader_all
+    """
+    indices_labelled, indices_unlabelled = (
+        get_indices(gene_dataset.labels, [n_labelled_samples_per_class] * gene_dataset.n_labels)
+    )
+    data_loader_all = DataLoader(gene_dataset, collate_fn=gene_dataset.collate_fn, shuffle=True, **kwargs_data_loader)
+    data_loader_labelled = DataLoader(gene_dataset, collate_fn=gene_dataset.collate_fn,
+                                      sampler=SubsetRandomSampler(indices_labelled), **kwargs_data_loader)
+    data_loader_unlabelled = DataLoader(gene_dataset, collate_fn=gene_dataset.collate_fn,
+                                        sampler=SubsetRandomSampler(indices_unlabelled), **kwargs_data_loader)
+    return data_loader_all, data_loader_labelled, data_loader_unlabelled

--- a/scvi/dataset/utils.py
+++ b/scvi/dataset/utils.py
@@ -40,3 +40,23 @@ def get_data_loaders(gene_dataset, n_labelled_samples_per_class, **kwargs_data_l
     data_loader_unlabelled = DataLoader(gene_dataset, collate_fn=gene_dataset.collate_fn,
                                         sampler=SubsetRandomSampler(indices_unlabelled), **kwargs_data_loader)
     return data_loader_all, data_loader_labelled, data_loader_unlabelled
+
+
+def get_raw_data(*data_loaders):
+    """
+    From a list of data_loaders, return the numpy array suitable for classification with sklearn
+    :param data_loaders: a sequence of data_loaders arguments
+    :return: a sequence of (data, labels) for each data_loader
+    """
+
+    def get_data_labels(data_loader):
+        if hasattr(data_loader, 'sampler'):
+            if hasattr(data_loader.sampler, 'indices'):
+                data = data_loader.dataset.X[data_loader.sampler.indices]
+                labels = data_loader.dataset.labels[data_loader.sampler.indices]
+        else:
+            data = data_loader.dataset.X
+            labels = data_loader.dataset.labels
+        return data, labels.ravel()
+
+    return [get_data_labels(data_loader) for data_loader in data_loaders]

--- a/scvi/metrics/classification.py
+++ b/scvi/metrics/classification.py
@@ -1,6 +1,33 @@
+from collections import namedtuple
+
+import numpy as np
 import torch
+from sklearn.ensemble import RandomForestClassifier
+from sklearn.model_selection import GridSearchCV
+from sklearn.svm import SVC
 
 from scvi.utils import no_grad, eval_modules, to_cuda
+
+Accuracy = namedtuple('Accuracy', ['unweighted', 'weighted', 'worst', 'accuracy_classes'])
+
+
+def compute_accuracy_tuple(y, labels):
+    labels = labels.ravel()
+    n_labels = len(np.unique(labels))
+    classes_probabilities = []
+    accuracy_classes = []
+    for cl in range(n_labels):
+        idx = labels == cl
+        classes_probabilities += [np.mean(idx)]
+        accuracy_classes += [np.mean((labels[idx] == y[idx])) if classes_probabilities[-1] else 0]
+        # This is also referred to as the "recall": p = n_true_positive / (n_false_negative + n_true_positive)
+        # ( We could also compute the "precision": p = n_true_positive / (n_false_positive + n_true_positive) )
+        accuracy_named_tuple = Accuracy(
+            unweighted=np.dot(accuracy_classes, classes_probabilities),
+            weighted=np.mean(accuracy_classes),
+            worst=np.min(accuracy_classes),
+            accuracy_classes=accuracy_classes)
+    return accuracy_named_tuple
 
 
 @no_grad()
@@ -28,3 +55,40 @@ def compute_accuracy(vae, data_loader, classifier=None):
     accuracy = (torch.cat(all_y_pred) == torch.cat(all_labels)).type(torch.float32).mean().item()
 
     return accuracy
+
+
+def compute_accuracy_svc(data_train, labels_train, data_test, labels_test, unit_test=False, verbose=0):
+    param_grid = [
+        {'C': [1, 10, 100, 1000], 'kernel': ['linear']},
+        {'C': [1, 10, 100, 1000], 'gamma': [0.001, 0.0001], 'kernel': ['rbf']}]
+    if unit_test:
+        param_grid = [{'C': [1], 'kernel': ['linear']}]
+    svc = SVC()
+
+    clf = GridSearchCV(svc, param_grid, verbose=verbose)
+    clf.fit(data_train, labels_train)
+
+    # Predicting the labels
+    y_pred_test = clf.predict(data_test)
+    y_pred_train = clf.predict(data_train)
+
+    return (compute_accuracy_tuple(y_pred_train, labels_train),
+            compute_accuracy_tuple(y_pred_test, labels_test))
+
+
+def compute_accuracy_rf(data_train, labels_train, data_test, labels_test, unit_test=False, verbose=0):
+    param_grid = {'max_depth': np.arange(3, 10), 'n_estimators': [10, 50, 100, 200]}
+    if unit_test:
+        param_grid = [{'max_depth': [3], 'n_estimators': [10]}]
+
+    rf = RandomForestClassifier(max_depth=2, random_state=0)
+
+    clf = GridSearchCV(rf, param_grid, verbose=verbose)
+    clf.fit(data_train, labels_train)
+
+    # Predicting the labels
+    y_pred_test = clf.predict(data_test)
+    y_pred_train = clf.predict(data_train)
+
+    return (compute_accuracy_tuple(y_pred_train, labels_train),
+            compute_accuracy_tuple(y_pred_test, labels_test))

--- a/scvi/metrics/stats.py
+++ b/scvi/metrics/stats.py
@@ -10,7 +10,7 @@ from scvi.models import VAE, VAEC, SVAEC
 
 class Stats:
     def __init__(self, verbose=True, record_freq=5, n_epochs=-1, benchmark=False, names=['train', 'test', 'val']):
-        self.verbose = verbose
+        self.verbose = verbose if not benchmark else False
         self.record_freq = record_freq
         self.n_epochs = n_epochs
         self.benchmark = benchmark

--- a/scvi/models/base.py
+++ b/scvi/models/base.py
@@ -1,0 +1,29 @@
+''' Defines the abstract types and required signatures for models '''
+
+from abc import ABC, abstractmethod
+
+
+class BaseModel(ABC):
+    @abstractmethod
+    def forward(self, x, local_l_mean, local_l_var, batch_index=None, y=None):
+        '''
+        :return: reconst_loss, kl_divergence
+        '''
+        pass
+
+    @abstractmethod
+    def get_latents(self, x, y=None):
+        '''
+        :param x: sample_batch
+        :param y: labels
+        :return: an array [z1, z2] the sampled variables from bottom to top
+        '''
+        pass
+
+
+class SemiSupervisedModel(BaseModel):
+    def classify(self, x):
+        '''
+        :return: a softmax probability over all labels for every sample in x.
+        '''
+        pass

--- a/scvi/models/classifier.py
+++ b/scvi/models/classifier.py
@@ -1,0 +1,36 @@
+import torch
+import torch.nn.functional as F
+from sklearn.linear_model import LogisticRegression
+from torch import nn as nn
+from torch.nn import Linear
+
+from scvi.metrics.clustering import get_latent_mean
+from scvi.models.modules import FCLayers
+
+
+class Classifier(nn.Module):
+    def __init__(self, n_input, n_hidden=128, n_labels=10, n_layers=1, dropout_rate=0.1, use_cuda=False):
+        super(Classifier, self).__init__()
+        self.layers = FCLayers(n_in=n_input, n_out=n_hidden, n_layers=n_layers, n_hidden=n_hidden,
+                               dropout_rate=dropout_rate)
+        self.classifier = nn.Sequential(self.layers, nn.Linear(n_hidden, n_labels), nn.Softmax(dim=-1))
+
+        self.use_cuda = use_cuda and torch.cuda.is_available()
+        if self.use_cuda:
+            self.cuda()
+
+    def forward(self, x):
+        return self.classifier(x)
+
+
+class LinearLogRegClassifier(Linear):
+    def update_parameters(self, vae, data_loader_classification):
+        data_train, _, labels_train = get_latent_mean(vae, data_loader_classification)
+        log_reg = LogisticRegression()
+        log_reg.fit(data_train, labels_train)
+
+        self.weight = nn.Parameter(torch.from_numpy(log_reg.coef_).to(self.weight.device).type(self.weight.dtype))
+        self.bias = nn.Parameter(torch.from_numpy(log_reg.intercept_).to(self.bias.device).type(self.bias.dtype))
+
+    def forward(self, input):
+        return F.softmax(super(LinearLogRegClassifier, self).forward(input), dim=-1)

--- a/scvi/models/modules.py
+++ b/scvi/models/modules.py
@@ -143,20 +143,3 @@ class Decoder(nn.Module):
         p_m = self.mean_decoder(p)
         p_v = torch.exp(self.var_decoder(p))
         return p_m, p_v
-
-
-# Classifier
-class Classifier(nn.Module):
-    def __init__(self, n_input, n_hidden=128, n_labels=10, n_layers=1, dropout_rate=0.1, use_cuda=False):
-        super(Classifier, self).__init__()
-        self.layers = FCLayers(n_in=n_input, n_out=n_hidden, n_layers=n_layers, n_hidden=n_hidden,
-                               dropout_rate=dropout_rate)
-        self.classifier = nn.Sequential(self.layers, nn.Linear(n_hidden, n_labels), nn.Softmax(dim=-1))
-
-        self.use_cuda = use_cuda and torch.cuda.is_available()
-        if self.use_cuda:
-            self.cuda()
-
-    def forward(self, x):
-        # Parameters for latent distribution
-        return self.classifier(x)

--- a/scvi/models/svaec.py
+++ b/scvi/models/svaec.py
@@ -93,49 +93,37 @@ class SVAEC(nn.Module, SemiSupervisedModel):
     def forward(self, x, local_l_mean, local_l_var, batch_index=None, y=None):
         is_labelled = False if y is None else True
 
-        xs, ys = (x, y)
-        xs_ = torch.log(1 + xs)
-        qz1_m, qz1_v, z1_ = self.z_encoder(xs_)
-        z1 = z1_
+        x_ = torch.log(1 + x)
+        qz1_m, qz1_v, z1 = self.z_encoder(x_)
+        ql_m, ql_v, library = self.l_encoder(x_)
+
         # Enumerate choices of label
-        ys, xs, batch_index, local_l_var, local_l_mean, qz1_m, qz1_v, z1 = (
+        ys, z1s = (
             broadcast_labels(
-                ys, xs, batch_index, local_l_var, local_l_mean, qz1_m, qz1_v, z1, n_broadcast=self.n_labels
+                y, z1, n_broadcast=self.n_labels
             )
         )
-
-        xs_ = torch.log(1 + xs)
-
-        qz2_m, qz2_v, z2 = self.encoder_z2_z1(z1, ys)
+        qz2_m, qz2_v, z2 = self.encoder_z2_z1(z1s, ys)
         pz1_m, pz1_v = self.decoder_z1_z2(z2, ys)
-
-        # Sampling
-        ql_m, ql_v, library = self.l_encoder(xs_)  # let's keep that ind. of y
-
         px_scale, px_rate, px_dropout = self.decoder(self.dispersion, z1, library, batch_index)
-
-        reconst_loss = -log_zinb_positive(xs, px_rate, torch.exp(self.px_r), px_dropout)
+        reconst_loss = -log_zinb_positive(x, px_rate, torch.exp(self.px_r), px_dropout)
 
         # KL Divergence
         mean = torch.zeros_like(qz2_m)
         scale = torch.ones_like(qz2_v)
 
         kl_divergence_z2 = kl(Normal(qz2_m, torch.sqrt(qz2_v)), Normal(mean, scale)).sum(dim=1)
-        loss_z1 = (- Normal(pz1_m, torch.sqrt(pz1_v)).log_prob(z1) +
-                   Normal(qz1_m, torch.sqrt(qz1_v)).log_prob(z1)).sum(dim=1)
+        loss_z1_unweight = - Normal(pz1_m, torch.sqrt(pz1_v)).log_prob(z1s).sum(dim=-1)
+        loss_z1_weight = Normal(qz1_m, torch.sqrt(qz1_v)).log_prob(z1).sum(dim=-1)
         kl_divergence_l = kl(Normal(ql_m, torch.sqrt(ql_v)), Normal(local_l_mean, torch.sqrt(local_l_var))).sum(dim=1)
-        kl_divergence = kl_divergence_z2 + loss_z1 + kl_divergence_l
 
         if is_labelled:
-            return reconst_loss, kl_divergence
+            return reconst_loss + loss_z1_weight + loss_z1_unweight, kl_divergence_z2 + kl_divergence_l
 
-        reconst_loss = reconst_loss.view(self.n_labels, -1)
-        kl_divergence = kl_divergence.view(self.n_labels, -1)
+        probs = self.classifier(z1)
+        reconst_loss += (loss_z1_weight + ((loss_z1_unweight).view(self.n_labels, -1).t() * probs).sum(dim=1))
 
-        probs = self.classifier(z1_)
-        reconst_loss = (reconst_loss.t() * probs).sum(dim=1)
-        kl_divergence = (kl_divergence.t() * probs).sum(dim=1)
-
+        kl_divergence = (kl_divergence_z2.view(self.n_labels, -1).t() * probs).sum(dim=1)
         kl_divergence += kl(Multinomial(probs=probs), Multinomial(probs=self.y_prior))
 
         return reconst_loss, kl_divergence

--- a/scvi/models/utils.py
+++ b/scvi/models/utils.py
@@ -46,4 +46,4 @@ def enumerate_discrete(x, y_dim):
 
 @register_kl(Multinomial, Multinomial)
 def kl_multinomial_multinomial(p, q):
-    return torch.sum(torch.mul(p.probs, torch.log(q.probs) - torch.log(p.probs + 1e-8)), dim=-1)
+    return torch.sum(torch.mul(p.probs, torch.log(p.probs + 1e-8) - torch.log(q.probs + 1e-8)), dim=-1)

--- a/scvi/models/vae.py
+++ b/scvi/models/vae.py
@@ -9,12 +9,13 @@ from torch.distributions import Normal, kl_divergence as kl
 from scvi.metrics.log_likelihood import log_zinb_positive, log_nb_positive
 from scvi.models.modules import Encoder, DecoderSCVI
 from scvi.models.utils import one_hot
+from .base import BaseModel
 
 torch.backends.cudnn.benchmark = True
 
 
 # VAE model
-class VAE(nn.Module):
+class VAE(nn.Module, BaseModel):
     def __init__(self, n_input, n_hidden=128, n_latent=10, n_layers=1, dropout_rate=0.1, dispersion="gene",
                  log_variational=True, reconstruction_loss="zinb", n_batch=0, n_labels=0, use_cuda=False):
         super(VAE, self).__init__()
@@ -24,6 +25,7 @@ class VAE(nn.Module):
         # Automatically desactivate if useless
         self.n_batch = 0 if n_batch == 1 else n_batch
         self.n_labels = n_labels
+        self.n_latent_layers = 1
 
         if self.dispersion == "gene":
             self.px_r = torch.nn.Parameter(torch.randn(n_input, ))
@@ -44,6 +46,14 @@ class VAE(nn.Module):
         self.use_cuda = use_cuda and torch.cuda.is_available()
         if self.use_cuda:
             self.cuda()
+
+    def get_latents(self, x, y=None):
+        x = torch.log(1 + x)
+        # Here we compute as little as possible to have q(z|x)
+        qz_m, qz_v, z = self.z_encoder(x)
+        if self.training:
+            z = qz_m
+        return [z]
 
     def sample_from_posterior_z(self, x, y=None):
         x = torch.log(1 + x)
@@ -74,7 +84,7 @@ class VAE(nn.Module):
     def sample(self, z):
         return self.px_scale_decoder(z)
 
-    def forward(self, x, local_l_mean, local_l_var, batch_index=None, y=None):  # same signature as loss
+    def forward(self, x, local_l_mean, local_l_var, batch_index=None, y=None):
         # Parameters for z latent distribution
         x_ = x
         if self.log_variational:

--- a/scvi/train.py
+++ b/scvi/train.py
@@ -101,9 +101,9 @@ def train_semi_supervised_jointly(vae, data_loader_all, data_loader_labelled, da
 
 
 @enable_grad()
-def train_semi_supervised_alternatively(vae, data_loader_all, data_loader_labelled, data_loader_unlabelled,
-                                        n_epochs=20, lr=0.001, kl=None, benchmark=False, lr_classification=0.1,
-                                        record_freq=1, n_epochs_classifier=1):
+def train_semi_supervised_alternately(vae, data_loader_all, data_loader_labelled, data_loader_unlabelled,
+                                      n_epochs=20, lr=0.001, kl=None, benchmark=False, lr_classification=0.1,
+                                      record_freq=1, n_epochs_classifier=1):
     # Defining the optimizer
     optimizer = torch.optim.Adam(filter(lambda p: p.requires_grad, vae.parameters()), lr=lr)
 

--- a/scvi/train.py
+++ b/scvi/train.py
@@ -50,73 +50,117 @@ def train(vae, data_loader_train, data_loader_test, n_epochs=20, lr=0.001, kl=No
 
 
 @enable_grad()
-def train_semi_supervised(vae, data_loader_train, data_loader_test, n_epochs=20, lr=0.001, kl=None, benchmark=False,
-                          classification_ratio=0):
+def train_semi_supervised_jointly(vae, data_loader_all, data_loader_labelled, data_loader_unlabelled, n_epochs=20,
+                                  lr=0.001,
+                                  kl=None, benchmark=False, record_freq=1, classification_ratio=100):
     # Defining the optimizer
     optimizer = torch.optim.Adam(filter(lambda p: p.requires_grad, vae.parameters()), lr=lr)
 
     # Getting access to the stats during training
-    stats = Stats(n_epochs=n_epochs, benchmark=benchmark)
-    stats.callback(vae, data_loader_train, data_loader_test)
+    stats = Stats(n_epochs=n_epochs, benchmark=benchmark, names=["labelled", "unlabelled"], record_freq=record_freq)
+    stats.callback(vae, data_loader_labelled, data_loader_unlabelled)
     early_stopping = EarlyStopping(benchmark=benchmark)
 
     # Training the model
     for epoch in range(n_epochs):
         # initialize kl, reconst
         total_train_loss = 0
-        for i_batch, (tensors_train, tensors_test) in enumerate(zip(data_loader_train, cycle(data_loader_test))):
+        for i_batch, (tensors, tensor_classification) in enumerate(zip(data_loader_all, cycle(data_loader_labelled))):
             with torch.no_grad():
                 if vae.use_cuda:
-                    tensors_train = to_cuda(tensors_train)
-                    tensors_test = to_cuda(tensors_test)
-            sample_batch_train, local_l_mean_train, local_l_var_train, batch_index_train, labels_train = tensors_train
-            sample_batch_test, local_l_mean_test, local_l_var_test, batch_index_test, _ = tensors_test
-            sample_batch_train = sample_batch_train.type(torch.float32)
-            sample_batch_test = sample_batch_test.type(torch.float32)
+                    tensors = to_cuda(tensors)
+            sample_batch, local_l_mean, local_l_var, batch_index, _ = tensors
+            sample_batch = sample_batch.type(torch.float32)
 
             if kl is None:
                 kl_ponderation = min(1, epoch / 400.)
             else:
                 kl_ponderation = kl
 
-            reconst_loss_train, kl_divergence_train = vae(sample_batch_train, local_l_mean_train, local_l_var_train,
-                                                          batch_index=batch_index_train, y=labels_train)
-            reconst_loss_test, kl_divergence_test = vae(sample_batch_test, local_l_mean_test, local_l_var_test,
-                                                        batch_index=batch_index_test, y=None)
+            reconst_loss, kl_divergence = vae(sample_batch, local_l_mean, local_l_var, batch_index=batch_index, y=None)
+            loss = torch.mean(reconst_loss + kl_ponderation * kl_divergence)
 
-            train_loss = torch.mean(reconst_loss_train + kl_ponderation * kl_divergence_train)
-            test_loss = torch.mean(reconst_loss_test + kl_ponderation * kl_divergence_test)
-            train_test_loss = train_loss + test_loss
+            # Add a classification loss
+            if hasattr(vae, "classify"):
+                with torch.no_grad():
+                    if vae.use_cuda:
+                        tensor_classification = to_cuda(tensor_classification)
+                sample_batch_cl, _, _, _, labels_cl = tensor_classification
+                sample_batch_cl = sample_batch_cl.type(torch.float32)
+                classification_loss = F.cross_entropy(vae.classify(sample_batch_cl), labels_cl.view(-1))
+                loss += classification_loss * classification_ratio
 
-            # Add a classification loss (most semi supervised VAE papers do)
-            if hasattr(vae, "classify") and labels_train is not None:
-                classification_loss = F.cross_entropy(vae.classify(sample_batch_train), labels_train.view(-1))
-                train_test_loss += classification_loss * classification_ratio
-
-            batch_size = sample_batch_train.size(0)
-            total_train_loss += train_loss.item() * batch_size
             optimizer.zero_grad()
-            train_test_loss.backward()
+            loss.backward()
             optimizer.step()
-
         if not early_stopping.update(total_train_loss):
             break
-        stats.callback(vae, data_loader_train, data_loader_test)
+        stats.callback(vae, data_loader_labelled, data_loader_unlabelled)
     stats.display_time()
     return stats
 
 
 @enable_grad()
-def train_classifier(vae, classifier, data_loader_train, data_loader_test, n_epochs=250, lr=0.1):
-    # Train classifier on the z latent space of a vae
-    optimizer = torch.optim.Adam(classifier.parameters(), lr=lr, eps=0.01)
+def train_semi_supervised_alternatively(vae, data_loader_all, data_loader_labelled, data_loader_unlabelled,
+                                        n_epochs=20, lr=0.001, kl=None, benchmark=False, lr_classification=0.1,
+                                        record_freq=1, n_epochs_classifier=1):
+    # Defining the optimizer
+    optimizer = torch.optim.Adam(filter(lambda p: p.requires_grad, vae.parameters()), lr=lr)
 
     # Getting access to the stats during training
-    stats = Stats(n_epochs=n_epochs)
-    stats.callback(vae, data_loader_train, data_loader_test, classifier=classifier)
+    stats = Stats(n_epochs=n_epochs, benchmark=benchmark, names=["labelled", "unlabelled"], record_freq=record_freq)
+    stats.callback(vae, data_loader_labelled, data_loader_unlabelled)
+    early_stopping = EarlyStopping(benchmark=benchmark)
 
-    for epoch in range(1, n_epochs + 1):
-        for i_batch, tensors in enumerate(data_loader_train):
+    # Training the model
+    for epoch in range(n_epochs):
+        # initialize kl, reconst
+        total_train_loss = 0
+        for i_batch, tensors in enumerate(data_loader_all):
+            with torch.no_grad():
+                if vae.use_cuda:
+                    tensors = to_cuda(tensors)
+            sample_batch, local_l_mean, local_l_var, batch_index, _ = tensors
+            sample_batch = sample_batch.type(torch.float32)
+
+            if kl is None:
+                kl_ponderation = min(1, epoch / 400.)
+            else:
+                kl_ponderation = kl
+
+            reconst_loss, kl_divergence = vae(sample_batch, local_l_mean, local_l_var, batch_index=batch_index, y=None)
+            loss = torch.mean(reconst_loss + kl_ponderation * kl_divergence)
+            optimizer.zero_grad()
+            loss.backward()
+            optimizer.step()
+
+        # Optimize the classification loss at the end of each epoch
+        if hasattr(vae, "classifier"):
+            if hasattr(vae.classifier, "update_parameters"):
+                vae.classifier.update_parameters(vae, data_loader_labelled)
+            else:
+                # Minimize the cross entropy over multiple batches of the training data.
+                train_classifier(vae, vae.classifier, data_loader_labelled,
+                                 n_epochs=n_epochs_classifier, lr=lr_classification, benchmark=True)
+
+        if not early_stopping.update(total_train_loss):
+            break
+        stats.callback(vae, data_loader_labelled, data_loader_unlabelled)
+    stats.display_time()
+    return stats
+
+
+@enable_grad()
+def train_classifier(vae, classifier, *data_loaders, n_epochs=250, lr=0.1, benchmark=False):
+    # Train classifier on the z latent space of a vae
+    optimizer = torch.optim.Adam(classifier.parameters(), lr=lr)
+
+    # Getting access to the stats during training
+    stats = Stats(n_epochs=n_epochs, benchmark=benchmark)
+    stats.callback(vae, *data_loaders, classifier=classifier)
+
+    for epoch in range(n_epochs):
+        for i_batch, tensors in enumerate(data_loaders[0]):
             if vae.use_cuda:
                 tensors = to_cuda(tensors)
             sample_batch_train, _, _, _, labels_train = tensors
@@ -129,6 +173,6 @@ def train_classifier(vae, classifier, data_loader_train, data_loader_test, n_epo
             loss.backward()
             optimizer.step()
 
-        stats.callback(vae, data_loader_train, data_loader_test, classifier=classifier)
+        stats.callback(vae, *data_loaders, classifier=classifier)
 
     return stats


### PR DESCRIPTION
* Semi supervised:

    * Add `get_indices` and `get_data_loaders` functions, useful for semi_supervised training

    * Correction of the semi-supervised training scheme, where if dataloaders were unbalanced (more labelled samples than unlabelled for instance), the actual loss minimized was wrong. Now the two new training schemes are

        * `train_semi_supervised_jointly` : the `classification_ratio` parameter can trigger a difference between the relative importance of classification vs. reconstruction loss

        * `train_semi_supervised_alternately` :  at the end of each epoch to optimize the ELBO, the classification error is, in turn, optimized.

    * Better naming convention: train/test => labelled/unlabelled

    * optional in SVAEC: `LinearLogRegClassifier` classifier, only updated every epoch (using sklearn). It acts like a NN on the forward pass - ie. for unlabelled samples,  computations are still entirely happening on GPU. This works best with the `train_semi_supervised_alternately` in the caseof the purified dataset populations

* Others:

    * added `get_latent_mean` and `get_latents` functions. (Only `get_latent` before). Still backward compatible, but removes the need to call .cpu().numpy(). Useful for models with more than one hidden stochastic layer.

    * Correct wrong multinomial formula

    * Add `base.py` file to normalize algorithms methods (VAE, VAEC, SVAEC)