### PR TITLE
harmonization for n_layer==1

### DIFF
--- a/scvi/models/modules.py
+++ b/scvi/models/modules.py
@@ -8,88 +8,51 @@ from scvi.models.utils import one_hot
 
 
 class FCLayers(nn.Module):
-    def __init__(self, n_in, n_out, n_hidden=128, n_layers=1, dropout_rate=0.1):
+    def __init__(self, n_in, n_out, n_cat_list=[], n_layers=1, n_hidden=128, dropout_rate=0.1):
         super(FCLayers, self).__init__()
         layers_dim = [n_in] + (n_layers - 1) * [n_hidden] + [n_out]
-        self.fc_layers = FCLayers._sequential(layers_dim, dropout_rate=dropout_rate)
-
-    def forward(self, x, *os):
-        return self.fc_layers(x)
-
-    @staticmethod
-    def create(n_in, n_out, n_cat=0, n_hidden=128, n_layers=1, dropout_rate=0.1):
-        if type(n_cat) is int:
-            if n_cat == 0:
-                return FCLayers(n_in, n_out, n_hidden=n_hidden, n_layers=n_layers, dropout_rate=dropout_rate)
-            else:
-                return OneHotFCLayers(n_in, n_out, n_cat=n_cat, n_hidden=n_hidden, n_layers=n_layers,
-                                      dropout_rate=dropout_rate)
-        elif type(n_cat) is list:
-            return ManyOneHotFCLayers(n_in, n_out, n_cat_list=n_cat,
-                                      n_hidden=n_hidden, n_layers=n_layers, dropout_rate=dropout_rate)
-
-    @staticmethod
-    def _sequential(layers_dim, n_cat=0, dropout_rate=0.1):
-        return nn.Sequential(collections.OrderedDict(
+        self.n_cat_list = [n_cat if n_cat > 1 else 0 for n_cat in n_cat_list]  # n_cat = 1 will be ignored
+        self.fc_layers = nn.Sequential(collections.OrderedDict(
             [('Layer {}'.format(i), nn.Sequential(
                 nn.Dropout(p=dropout_rate),
-                nn.Linear(n_in + n_cat, n_out),
+                nn.Linear(n_in + sum(n_cat_list), n_out),
                 nn.BatchNorm1d(n_out, eps=1e-3, momentum=0.99),
                 nn.ReLU())) for i, (n_in, n_out) in enumerate(zip(layers_dim[:-1], layers_dim[1:]))]))
 
-
-class OneHotFCLayers(nn.Module):
-    def __init__(self, n_in, n_out, n_cat, n_hidden=128, n_layers=1, dropout_rate=0.1):
-        super(OneHotFCLayers, self).__init__()
-        layers_dim = [n_in] + (n_layers - 1) * [n_hidden] + [n_out]
-        self.n_cat = n_cat
-        self.fc_layers = FCLayers._sequential(layers_dim, n_cat=n_cat, dropout_rate=dropout_rate)
-
-    def forward(self, x, o, *os):
-        if o.size(1) != self.n_cat:
-            o = one_hot(o, self.n_cat)
-        for layer in self.fc_layers:
-            x = layer(torch.cat((x, o), 1))
-        return x
-
-
-class ManyOneHotFCLayers(nn.Module):
-    def __init__(self, n_in, n_out, n_cat_list, n_hidden=128, n_layers=1, dropout_rate=0.1):
-        super(ManyOneHotFCLayers, self).__init__()
-        layers_dim = [n_in] + (n_layers - 1) * [n_hidden] + [n_out]
-        self.n_cat_list = n_cat_list
-        self.fc_layers = FCLayers._sequential(layers_dim, n_cat=sum(n_cat_list), dropout_rate=dropout_rate)
-
-    def forward(self, x, *os):
-        one_hot_os = []
-        for i, o in enumerate(os):
-            if o is not None and self.n_cat_list[i]:
-                one_hot_o = o
-                if o.size(1) != self.n_cat_list[i]:
-                    one_hot_o = one_hot(o, self.n_cat_list[i])
-                elif o.size(1) == 1 and self.n_cat_list[i] == 1:
-                    one_hot_o = o.type(torch.float32)
-                one_hot_os += [one_hot_o]
-        for layer in self.fc_layers:
-            x = layer(torch.cat((x,) + tuple(one_hot_os), 1))
+    def forward(self, x, *cat_list):
+        one_hot_cat_list = []  # for generality in this list many indices useless.
+        assert len(self.n_cat_list) == len(cat_list), "nb. categorical args provided doesn't match init. params."
+        for n_cat, cat in zip(self.n_cat_list, cat_list):
+            assert not (n_cat and cat is None), "cat not provided while n_cat != 0 in init. params."
+            if n_cat > 1:  # n_cat = 1 will be ignored - no additional information
+                if cat.size(1) != n_cat:
+                    one_hot_cat = one_hot(cat, n_cat)
+                else:
+                    one_hot_cat = cat  # cat has already been one_hot encoded
+                one_hot_cat_list += [one_hot_cat]
+        for layers in self.fc_layers:
+            for layer in layers:
+                if isinstance(layer, nn.Linear):
+                    x = torch.cat((x, *one_hot_cat_list), 1)
+                x = layer(x)
         return x
 
 
 # Encoder
 class Encoder(nn.Module):
-    def __init__(self, n_input, n_hidden=128, n_latent=10, n_cat=0, n_layers=1, dropout_rate=0.1):
+    def __init__(self, n_input, n_latent=10, n_cat_list=[], n_layers=1, n_hidden=128, dropout_rate=0.1):
         super(Encoder, self).__init__()
-        self.encoder = FCLayers.create(n_in=n_input, n_out=n_hidden, n_cat=n_cat, n_layers=n_layers, n_hidden=n_hidden,
-                                       dropout_rate=dropout_rate)
+        self.encoder = FCLayers(n_in=n_input, n_out=n_hidden, n_cat_list=n_cat_list, n_layers=n_layers,
+                                n_hidden=n_hidden, dropout_rate=dropout_rate)
         self.mean_encoder = nn.Linear(n_hidden, n_latent)
         self.var_encoder = nn.Linear(n_hidden, n_latent)
 
     def reparameterize(self, mu, var):
         return Normal(mu, var.sqrt()).rsample()
 
-    def forward(self, x, o=None):
+    def forward(self, x, *cat_list):
         # Parameters for latent distribution
-        q = self.encoder(x, o)
+        q = self.encoder(x, *cat_list)
         q_m = self.mean_encoder(q)
         q_v = torch.exp(torch.clamp(self.var_encoder(q), -5, 5))  # (computational stability safeguard)
         latent = self.reparameterize(q_m, q_v)
@@ -98,11 +61,10 @@ class Encoder(nn.Module):
 
 # Decoder
 class DecoderSCVI(nn.Module):
-    def __init__(self, n_latent, n_input, n_hidden=128, n_layers=1, dropout_rate=0.1, n_batch=0, n_labels=0):
+    def __init__(self, n_latent, n_input, n_cat_list=[], n_layers=1, n_hidden=128, dropout_rate=0.1):
         super(DecoderSCVI, self).__init__()
-        self.n_batch = n_batch
-        self.px_decoder = FCLayers.create(n_in=n_latent, n_out=n_hidden, n_layers=n_layers, n_hidden=n_hidden,
-                                          dropout_rate=dropout_rate, n_cat=[n_batch, n_labels])
+        self.px_decoder = FCLayers(n_in=n_latent, n_out=n_hidden, n_cat_list=n_cat_list, n_layers=n_layers,
+                                   n_hidden=n_hidden, dropout_rate=dropout_rate)
 
         # mean gamma
         self.px_scale_decoder = nn.Sequential(nn.Linear(n_hidden, n_input), nn.Softmax(dim=-1))
@@ -113,9 +75,9 @@ class DecoderSCVI(nn.Module):
         # dropout
         self.px_dropout_decoder = nn.Linear(n_hidden, n_input)
 
-    def forward(self, dispersion, z, library, batch_index=None, y=None):
+    def forward(self, dispersion, z, library, *cat_list):
         # The decoder returns values for the parameters of the ZINB distribution
-        px = self.px_decoder(z, batch_index, y)
+        px = self.px_decoder(z, *cat_list)
         px_scale = self.px_scale_decoder(px)
         px_dropout = self.px_dropout_decoder(px)
         # Clamp to high value: exp(12) ~ 160000 to avoid nans (computational stability)
@@ -129,17 +91,17 @@ class DecoderSCVI(nn.Module):
 
 # Decoder
 class Decoder(nn.Module):
-    def __init__(self, n_latent, n_output, n_cat=0, n_hidden=128, n_layers=1, dropout_rate=0.1):
+    def __init__(self, n_latent, n_output, n_cat_list=[], n_layers=1, n_hidden=128, dropout_rate=0.1):
         super(Decoder, self).__init__()
-        self.decoder = FCLayers.create(n_in=n_latent, n_out=n_hidden, n_cat=n_cat, n_layers=n_layers,
-                                       n_hidden=n_hidden, dropout_rate=dropout_rate)
+        self.decoder = FCLayers(n_in=n_latent, n_out=n_hidden, n_cat_list=n_cat_list, n_layers=n_layers,
+                                n_hidden=n_hidden, dropout_rate=dropout_rate)
 
         self.mean_decoder = nn.Linear(n_hidden, n_output)
         self.var_decoder = nn.Linear(n_hidden, n_output)
 
-    def forward(self, x, o=None):
+    def forward(self, x, *cat_list):
         # Parameters for latent distribution
-        p = self.decoder(x, o)
+        p = self.decoder(x, *cat_list)
         p_m = self.mean_decoder(p)
         p_v = torch.exp(self.var_decoder(p))
         return p_m, p_v

--- a/scvi/models/svaec.py
+++ b/scvi/models/svaec.py
@@ -24,13 +24,12 @@ class SVAEC(nn.Module, SemiSupervisedModel):
 
         self.y_prior = y_prior if y_prior is not None else (1 / self.n_labels) * torch.ones(self.n_labels)
         # Automatically desactivate if useless
-        self.n_batch = 0 if n_batch == 1 else n_batch
-        self.z_encoder = Encoder(n_input, n_hidden=n_hidden, n_latent=n_latent, n_layers=n_layers,
+        self.n_batch = n_batch
+        self.z_encoder = Encoder(n_input, n_latent=n_latent, n_layers=n_layers, n_hidden=n_hidden,
                                  dropout_rate=dropout_rate)
-        self.l_encoder = Encoder(n_input, n_hidden=n_hidden, n_latent=1, n_layers=1,
-                                 dropout_rate=dropout_rate)
-        self.decoder = DecoderSCVI(n_latent, n_input, n_hidden=n_hidden, n_layers=n_layers,
-                                   dropout_rate=dropout_rate, n_batch=n_batch)
+        self.l_encoder = Encoder(n_input, n_latent=1, n_layers=1, n_hidden=n_hidden, dropout_rate=dropout_rate)
+        self.decoder = DecoderSCVI(n_latent, n_input, n_cat_list=[n_batch], n_layers=n_layers, n_hidden=n_hidden,
+                                   dropout_rate=dropout_rate)
 
         self.dispersion = 'gene'
         self.px_r = torch.nn.Parameter(torch.randn(n_input, ))
@@ -41,8 +40,10 @@ class SVAEC(nn.Module, SemiSupervisedModel):
         else:
             self.classifier = Classifier(n_latent, n_hidden, self.n_labels, n_layers, dropout_rate)
 
-        self.encoder_z2_z1 = Encoder(n_input=n_latent, n_cat=self.n_labels, n_latent=n_latent, n_layers=n_layers)
-        self.decoder_z1_z2 = Decoder(n_latent, n_latent, n_cat=self.n_labels, n_layers=n_layers)
+        self.encoder_z2_z1 = Encoder(n_latent, n_latent, n_cat_list=[self.n_labels], n_layers=n_layers,
+                                     n_hidden=n_hidden, dropout_rate=dropout_rate)
+        self.decoder_z1_z2 = Decoder(n_latent, n_latent, n_cat_list=[self.n_labels], n_layers=n_layers,
+                                     n_hidden=n_hidden, dropout_rate=dropout_rate)
 
         self.use_cuda = use_cuda and torch.cuda.is_available()
         if self.use_cuda:
@@ -77,15 +78,15 @@ class SVAEC(nn.Module, SemiSupervisedModel):
         return library
 
     def get_sample_scale(self, x, y=None, batch_index=None):
-        z = self.sample_from_posterior_z(x, y)
-        px = self.decoder.px_decoder(z, batch_index, y)
+        z = self.sample_from_posterior_z(x)
+        px = self.decoder.px_decoder(z, batch_index)
         px_scale = self.decoder.px_scale_decoder(px)
         return px_scale
 
     def get_sample_rate(self, x, y=None, batch_index=None):
         z = self.sample_from_posterior_z(x)
         library = self.sample_from_posterior_l(x)
-        px = self.decoder.px_decoder(z, batch_index, y)
+        px = self.decoder.px_decoder(z, batch_index)
         return self.decoder.px_scale_decoder(px) * torch.exp(library)
 
     def forward(self, x, local_l_mean, local_l_var, batch_index=None, y=None):

--- a/scvi/models/vae.py
+++ b/scvi/models/vae.py
@@ -23,7 +23,7 @@ class VAE(nn.Module, BaseModel):
         self.log_variational = log_variational
         self.reconstruction_loss = reconstruction_loss
         # Automatically desactivate if useless
-        self.n_batch = 0 if n_batch == 1 else n_batch
+        self.n_batch = n_batch
         self.n_labels = n_labels
         self.n_latent_layers = 1
 
@@ -36,12 +36,11 @@ class VAE(nn.Module, BaseModel):
         else:  # gene-cell
             pass
 
-        self.z_encoder = Encoder(n_input, n_hidden=n_hidden, n_latent=n_latent, n_layers=n_layers,
+        self.z_encoder = Encoder(n_input, n_latent=n_latent, n_layers=n_layers, n_hidden=n_hidden,
                                  dropout_rate=dropout_rate)
-        self.l_encoder = Encoder(n_input, n_hidden=n_hidden, n_latent=1, n_layers=1,
-                                 dropout_rate=dropout_rate)
-        self.decoder = DecoderSCVI(n_latent, n_input, n_hidden=n_hidden, n_layers=n_layers,
-                                   dropout_rate=dropout_rate, n_batch=n_batch)
+        self.l_encoder = Encoder(n_input, n_latent=1, n_layers=1, n_hidden=n_hidden, dropout_rate=dropout_rate)
+        self.decoder = DecoderSCVI(n_latent, n_input, n_cat_list=[n_batch], n_layers=n_layers, n_hidden=n_hidden,
+                                   dropout_rate=dropout_rate)
 
         self.use_cuda = use_cuda and torch.cuda.is_available()
         if self.use_cuda:


### PR DESCRIPTION
- sequential layers are [dropout(0.1), linear, batchnorm, relu]. Before, we concatenated [latent_features, one_hot_batch_index] as input to the sequential layer decoder, therefore submitting one_hot_batch_index to the dropout as well, and giving poor batch mixing entropy results. We customize the forward function to circumvent that problem.

- also simplifying the modules surrounding FCLayers. The additional feature is the ability to easily add edges from categorical variables in the graphical model, by specifying n_cat in the construct for each variable as a list (n_cat_list), and providing them as a sequence in the forward function.

Latent space vis. as supporting evidence ! (BE ~=0.6)
![new-3](https://user-images.githubusercontent.com/15527397/42413490-463e076e-81d6-11e8-98ea-c7bde13c5fab.png)
