### PR TITLE
mmd and adversarial wrapper for any VariationalInference instance

### DIFF
--- a/scvi/inference/__init__.py
+++ b/scvi/inference/__init__.py
@@ -5,9 +5,12 @@ from .variational_inference import (
     AlternateSemiSupervisedVariationalInference,
     JointSemiSupervisedVariationalInference
 )
+from .experimental_inference import adversarial_wrapper, mmd_wrapper
 
 __all__ = ['Inference',
            'ClassifierInference',
            'VariationalInference',
            'AlternateSemiSupervisedVariationalInference',
-           'JointSemiSupervisedVariationalInference']
+           'JointSemiSupervisedVariationalInference',
+           'adversarial_wrapper',
+           'mmd_wrapper']

--- a/scvi/inference/experimental_inference.py
+++ b/scvi/inference/experimental_inference.py
@@ -1,0 +1,89 @@
+import types
+from math import sqrt, pi
+
+import torch
+import torch.nn.functional as F
+from torch.distributions import Normal, Uniform
+
+from scvi.models.classifier import Classifier
+
+
+def mmd_fourier(x1, x2, bandwidth=2., dim_r=500):
+    d = x1.size(1)
+    rw_n = sqrt(2. / bandwidth) * Normal(0., 1. / sqrt(d)).sample((dim_r, d)).type(x1.type())
+    rb_u = 2 * pi * Uniform(0., 1.).sample((dim_r,)).type(x1.type())
+    rf0 = sqrt(2. / dim_r) * torch.cos(F.linear(x1, rw_n, rb_u))
+    rf1 = sqrt(2. / dim_r) * torch.cos(F.linear(x2, rw_n, rb_u))
+    result = (torch.pow(rf0.mean(dim=0) - rf1.mean(dim=0), 2)).sum()
+    return torch.sqrt(result)
+
+
+def mmd_objective(z, batch_index, n_batch):
+    mmd_method = mmd_fourier
+
+    z_dim = z.size(1)
+    batch_index = batch_index.view(-1)
+
+    # STEP 1: construct lists of samples in their proper batches
+    z_part = [z[batch_index == b_i] for b_i in range(n_batch)]
+
+    # STEP 2: add noise to all of them and get the mmd
+    mmd = 0
+    for j, z_j in enumerate(z_part):
+        z0_ = z_j
+        aux_z0 = Normal(0., 1.).sample((1, z_dim)).type(z0_.type())
+        z0 = torch.cat((z0_, aux_z0), dim=0)
+        if len(z_part) == 2:
+            z1_ = z_part[j + 1]
+            aux_z1 = Normal(0., 1.).sample((1, z_dim)).type(z1_.type())
+            z1 = torch.cat((z1_, aux_z1), dim=0)
+            return mmd_method(z0, z1)
+        z1 = z
+        mmd += mmd_method(z0, z1)
+    return mmd
+
+
+def mmd_loss(self, tensors, *next_tensors):
+    if self.epoch > self.warm_up:  # Leave a warm-up
+        sample_batch, _, _, batch_index, label = tensors
+        qm_z, _, _ = self.model.z_encoder(torch.log(1 + sample_batch), label)  # label only used in VAEC
+        loss = mmd_objective(qm_z, batch_index, self.gene_dataset.n_batches)
+    return type(self).loss(self, tensors, *next_tensors) + loss
+
+
+def mmd_wrapper(infer, warm_up=100, scale=50):
+    infer.warm_up = warm_up
+    infer.scale = scale
+    infer.loss = types.MethodType(adversarial_loss, infer)
+    infer.train = types.MethodType(adversarial_train, infer)
+    return infer
+
+
+def adversarial_loss(self, tensors, *next_tensors):
+    if self.epoch > self.warm_up:
+        sample_batch, _, _, batch_index, label = tensors
+        qm_z, _, _ = self.model.z_encoder(torch.log(1 + sample_batch), label)  # label only used in VAEC
+        cls_loss = (self.scale * F.cross_entropy(self.GAN1(qm_z), batch_index.view(-1)))
+        self.optimizer_GAN.zero_grad()
+        cls_loss.backward(retain_graph=True)
+        self.optimizer_GAN.step()
+    else:
+        cls_loss = 0
+    return type(self).loss(self, tensors, *next_tensors) - cls_loss
+
+
+def adversarial_train(self, n_epochs=20, lr=1e-3, weight_decay=1e-4):
+    self.GAN1 = Classifier(self.model.n_latent, n_labels=self.model.n_batch, n_layers=3)
+    if self.use_cuda:
+        self.GAN1.cuda()
+    self.optimizer_GAN = torch.optim.Adam(filter(lambda p: p.requires_grad, self.GAN1.parameters()), lr=lr,
+                                          weight_decay=weight_decay)
+    type(self).train(self, n_epochs=n_epochs, lr=lr)
+
+
+def adversarial_wrapper(infer, warm_up=100, scale=50):
+    infer.warm_up = warm_up
+    infer.scale = scale
+    infer.loss = types.MethodType(adversarial_loss, infer)
+    infer.train = types.MethodType(adversarial_train, infer)
+    return infer

--- a/tests/test_scvi.py
+++ b/tests/test_scvi.py
@@ -12,7 +12,7 @@ from scvi.dataset import BrainLargeDataset, CortexDataset, RetinaDataset, BrainS
     SeqfishDataset, SmfishDataset, BreastCancerDataset, MouseOBDataset, \
     GeneExpressionDataset, PurifiedPBMCDataset
 from scvi.inference import JointSemiSupervisedVariationalInference, AlternateSemiSupervisedVariationalInference, \
-    ClassifierInference, VariationalInference
+    ClassifierInference, VariationalInference, adversarial_wrapper, mmd_wrapper
 from scvi.metrics.adapt_encoder import adapt_encoder
 from scvi.models import VAE, SVAEC, VAEC
 from scvi.models.classifier import Classifier
@@ -74,6 +74,8 @@ def test_synthetic_2():
     infer_synthetic_vaec = JointSemiSupervisedVariationalInference(vaec, synthetic_dataset, use_cuda=use_cuda,
                                                                    early_stopping_metric='ll', frequency=1,
                                                                    save_best_state_metric='accuracy', on='labelled')
+    infer_synthetic_vaec = adversarial_wrapper(infer_synthetic_vaec, warm_up=5)
+    infer_synthetic_vaec = mmd_wrapper(infer_synthetic_vaec, warm_up=15)
     infer_synthetic_vaec.train(n_epochs=20)
     infer_synthetic_vaec.svc_rf(unit_test=True)
 


### PR DESCRIPTION
From two scmap datasets (segerstlope/muraro)

Without any of these wrapper, the batch entropy mixing gets up to 0.3.

Increasing the decoder number of layers to 3, it can go up to 0.45 (but slower to train then).

Still with only one layer, any of these penalites substantially increase the batch entropy mixing to around ~0.58 without imparing the likelihood nor the latent space as shown below.

![mmd-adversarial](https://user-images.githubusercontent.com/15527397/43364154-afe335fa-92c9-11e8-9eb3-dcf629a461a0.png)

The usage of these wrapper is quite flexible and only augment the train/loss method of the infer object, such that all its attributes and methods are preserved.

Ex usage in tests:

https://github.com/YosefLab/scVI/blob/bbc8668221a51393ded6690edf2f6f84b8de765d/tests/test_scvi.py#L72-L80

In this example we show that we can even combine both of them as simply as this. The warm-up parameter is the number of epochs at which to start adding the penalty (since it makes no sense and would probably impair training to add the penalty while the latent space hasn't started to shape).
