### PR TITLE
Tighter likelihood

### DIFF
--- a/scvi/benchmark.py
+++ b/scvi/benchmark.py
@@ -22,6 +22,7 @@ def benchmark(dataset, n_epochs=250, use_cuda=True):
     infer = VariationalInference(vae, dataset, use_cuda=use_cuda)
     infer.train(n_epochs=n_epochs)
     infer.ll('test')
+    infer.tighter_ll('test')
     infer.imputation('test', rate=0.1)  # assert ~ 2.1
     return infer
 

--- a/scvi/inference/variational_inference.py
+++ b/scvi/inference/variational_inference.py
@@ -19,7 +19,7 @@ from scvi.metrics.classification import unsupervised_clustering_accuracy
 from scvi.metrics.clustering import get_latent, entropy_batch_mixing, nn_overlap
 from scvi.metrics.differential_expression import de_stats, de_cortex
 from scvi.metrics.imputation import imputation, plot_imputation
-from scvi.metrics.log_likelihood import compute_log_likelihood
+from scvi.metrics.log_likelihood import compute_log_likelihood, compute_tighter_log_likelihood
 from . import Inference, ClassifierInference
 
 plt.switch_backend('agg')
@@ -66,6 +66,12 @@ class VariationalInference(Inference):
         return ll
 
     ll.mode = 'min'
+
+    def tighter_ll(self, name, verbose=False, n_mc_samples=1000):
+        ll = compute_tighter_log_likelihood(self.model, self.data_loaders[name], n_mc_samples)
+        if verbose:
+            print("True LL for %s is : %.4f" % (name, ll))
+        return ll
 
     def imputation(self, name, verbose=False, rate=0.1, n_samples=1, n_epochs=1, corruption="uniform",
                    title="Imputation"):

--- a/scvi/metrics/log_likelihood.py
+++ b/scvi/metrics/log_likelihood.py
@@ -2,6 +2,8 @@
 
 import torch
 import torch.nn.functional as F
+from torch.distributions import Normal
+import numpy as np
 
 
 def compute_log_likelihood(vae, data_loader):
@@ -16,6 +18,64 @@ def compute_log_likelihood(vae, data_loader):
                  if not (hasattr(data_loader, 'sampler') and hasattr(data_loader.sampler, 'indices')) else
                  len(data_loader.sampler.indices))
     return log_lkl / n_samples
+
+
+def compute_tighter_log_likelihood(vae, data_loader, n_samples_mc=100):
+    # Uses MC sampling to compute a tighter lower bound
+    log_lkl = 0
+    for i_batch, tensors in enumerate(data_loader):
+        sample_batch, local_l_mean, local_l_var, batch_index, labels = tensors
+        batch_log_lkl = compute_tighter_log_likelihood_sample(vae, sample_batch, local_l_mean,
+                                                              local_l_var, batch_index,
+                                                              labels, n_samples_mc=n_samples_mc)
+        log_lkl += torch.sum(batch_log_lkl).item()
+    n_samples = (len(data_loader.dataset)
+                 if not (hasattr(data_loader, 'sampler') and hasattr(data_loader.sampler, 'indices')) else
+                 len(data_loader.sampler.indices))
+    return log_lkl / n_samples
+
+
+def logsumexp(inputs, dim=None, keepdim=False):
+    """Numerically stable logsumexp.
+
+    Args:
+        inputs: A Variable with any shape.
+        dim: An integer.
+        keepdim: A boolean.
+
+    Returns:
+        Equivalent of log(sum(exp(inputs), dim=dim, keepdim=keepdim)).
+    """
+    # For a 1-D array x (any array along a single dimension),
+    # log sum exp(x) = s + log sum exp(x - s)
+    # with s = max(x) being a common choice.
+    if dim is None:
+        inputs = inputs.view(-1)
+        dim = 0
+    s, _ = torch.max(inputs, dim=dim, keepdim=True)
+    outputs = s + (inputs - s).exp().sum(dim=dim, keepdim=True).log()
+    if not keepdim:
+        outputs = outputs.squeeze(dim)
+    return outputs
+
+
+def compute_tighter_log_likelihood_sample(vae, sample_batch, local_l_mean, local_l_var, batch_index,
+                                          labels, n_samples_mc=100):
+    # Uses MC sampling to compute a tighter lower bound
+    x = torch.log(1 + sample_batch)
+    to_sum = torch.zeros(sample_batch.size()[0], n_samples_mc)
+    for i in range(n_samples_mc):
+        qz_m, qz_v, z = vae.z_encoder(x, labels)
+        reconst_loss, kl_divergence = vae(sample_batch, local_l_mean,
+                                          local_l_var,
+                                          batch_index=batch_index,
+                                          y=labels)
+        p_z = Normal(torch.zeros_like(z), torch.ones_like(z)).log_prob(z).sum(dim=-1)
+        p_x_z = reconst_loss
+        q_z_x = Normal(qz_m, qz_v).log_prob(z).sum(dim=-1)
+        to_sum[:, i] = p_z + p_x_z - q_z_x - np.log(n_samples_mc)
+
+    return logsumexp(to_sum, dim=-1)
 
 
 def log_zinb_positive(x, mu, theta, pi, eps=1e-8):


### PR DESCRIPTION
It gives slightly higher results than the reconstruction loss because the z drawn from q(z/x) has a higher likelihood under the measure q(z/x) than under p(z), which makes sense because of the samll discrepancy between the two distributions. The library size doesn't impact differently this computation of the LL. Closes #73 