### PR TITLE
remove async keyword argument 

### DIFF
--- a/scvi/inference/posterior.py
+++ b/scvi/inference/posterior.py
@@ -100,7 +100,7 @@ class Posterior:
         return map(self.to_cuda, iter(self.data_loader))
 
     def to_cuda(self, tensors):
-        return [t.cuda(async=self.use_cuda) if self.use_cuda else t for t in tensors]
+        return [t.cuda() if self.use_cuda else t for t in tensors]
 
     def update(self, data_loader_kwargs):
         posterior = copy.copy(self)


### PR DESCRIPTION
because it is a reserved word in python 3.7