### PR TITLE
fixed the duplicate classifier name in scanvi.state_dict()

### DIFF
--- a/scvi/models/classifier.py
+++ b/scvi/models/classifier.py
@@ -6,9 +6,11 @@ from scvi.models.modules import FCLayers
 class Classifier(nn.Module):
     def __init__(self, n_input, n_hidden=128, n_labels=10, n_layers=1, dropout_rate=0.1):
         super(Classifier, self).__init__()
-        self.layers = FCLayers(n_in=n_input, n_out=n_hidden, n_layers=n_layers, n_hidden=n_hidden,
-                               dropout_rate=dropout_rate, use_batch_norm=True)
-        self.classifier = nn.Sequential(self.layers, nn.Linear(n_hidden, n_labels), nn.Softmax(dim=-1))
+        self.classifier = nn.Sequential(
+            FCLayers(n_in=n_input, n_out=n_hidden, n_layers=n_layers,
+                     n_hidden=n_hidden, dropout_rate=dropout_rate, use_batch_norm=True),
+            nn.Linear(n_hidden, n_labels), nn.Softmax(dim=-1)
+        )
 
     def forward(self, x):
         return self.classifier(x)


### PR DESCRIPTION
fixes an issue raised in #225 