### PR TITLE
Using jupyter notebooks without json configuration files

### DIFF
--- a/scvi/inference/fish.py
+++ b/scvi/inference/fish.py
@@ -74,7 +74,7 @@ class TrainerFish(Trainer):
             self.adversarial_cls.cuda()
         self.optimizer_cls = torch.optim.Adam(filter(lambda p: p.requires_grad, self.adversarial_cls.parameters()),
                                               lr=lr, weight_decay=weight_decay)
-        super(TrainerFish, self).train(n_epochs=20, lr=1e-3, params=None)
+        super(TrainerFish, self).train(n_epochs=n_epochs, lr=1e-3, params=None)
 
     @property
     def posteriors_loop(self):

--- a/scvi/inference/fish.py
+++ b/scvi/inference/fish.py
@@ -74,7 +74,7 @@ class TrainerFish(Trainer):
             self.adversarial_cls.cuda()
         self.optimizer_cls = torch.optim.Adam(filter(lambda p: p.requires_grad, self.adversarial_cls.parameters()),
                                               lr=lr, weight_decay=weight_decay)
-        super(TrainerFish, self).train(n_epochs=n_epochs, lr=1e-3, params=None)
+        super(TrainerFish, self).train(n_epochs=20, lr=1e-3, params=None)
 
     @property
     def posteriors_loop(self):

--- a/tests/config_notebooks_tests/annotation.config.json
+++ b/tests/config_notebooks_tests/annotation.config.json
@@ -1,1 +1,0 @@
-{"save_path": "/tmp/pytest-of-romain/pytest-0/temp_data/", "n_epochs": 1, "n_labelled_samples_per_class": 3, "M_permutation": 10, "M_sampling": 1}

--- a/tests/config_notebooks_tests/basic_tutorial.config.json
+++ b/tests/config_notebooks_tests/basic_tutorial.config.json
@@ -1,1 +1,0 @@
-{"save_path": "/tmp/pytest-of-romain/pytest-0/temp_data/", "n_epochs": 1, "n_samples_tsne": 10, "n_samples_posterior_density": 2, "train_size": 1.0, "M_permutation": 10, "M_sampling": 1, "rate": 1.0}

--- a/tests/config_notebooks_tests/data_loading.config.json
+++ b/tests/config_notebooks_tests/data_loading.config.json
@@ -1,1 +1,0 @@
-{"save_path": "/tmp/pytest-of-romain/pytest-0/temp_data/"}

--- a/tests/config_notebooks_tests/scRNA_and_smFISH.config.json
+++ b/tests/config_notebooks_tests/scRNA_and_smFISH.config.json
@@ -1,1 +1,0 @@
-{"save_path": "/tmp/pytest-of-romain/pytest-0/temp_data/", "n_epochs": 1, "n_samples_tsne": 10, "n_samples_posterior_density": 2, "train_size": 0.5, "M_permutation": 10, "M_sampling": 10, "rate": 1.0}

--- a/tests/config_notebooks_tests/scVI_reproducibility.config.json
+++ b/tests/config_notebooks_tests/scVI_reproducibility.config.json
@@ -1,1 +1,0 @@
-{"save_path": "/tmp/pytest-of-romain/pytest-0/temp_data/", "n_epochs": 1, "n_samples_tsne": 10, "n_samples_posterior_density": 2, "train_size": 0.5, "M_permutation": 10, "M_sampling": 10, "rate": 1.0}

--- a/tests/notebooks/annotation.config.json
+++ b/tests/notebooks/annotation.config.json
@@ -1,3 +1,0 @@
-{
-    "save_path": "data/"
-}

--- a/tests/notebooks/annotation.ipynb
+++ b/tests/notebooks/annotation.ipynb
@@ -44,14 +44,8 @@
     }
    ],
    "source": [
-    "import os\n",
-    "\n",
     "save_path = 'data/'\n",
-    "n_epochs_all = None\n",
-    "n_labelled_samples_per_class = None\n",
-    "M_sampling_all = None\n",
-    "M_permutation_all = None\n",
-    "n_samples_tsne = None"
+    "n_epochs_all = None"
    ]
   },
   {
@@ -60,13 +54,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "assert n_samples_tsne == 10\n",
-    "assert n_epochs_all == 1\n",
-    "assert n_labelled_samples_per_class == 3\n",
-    "assert M_sampling_all == 1\n",
-    "assert M_permutation_all == 10\n",
-    "\n",
+    "import os\n",
     "import numpy as np\n",
+    "import torch\n",
     "import matplotlib.pyplot as plt\n",
     "from scvi.dataset import CortexDataset, LoomDataset\n",
     "from scvi.models import SCANVI, VAE\n",
@@ -112,7 +102,7 @@
    ],
    "source": [
     "simulation_1 = LoomDataset(filename='simulation_1.loom',\n",
-    "                           save_path=save_path+'simulation/',\n",
+    "                           save_path=os.path.join(save_path, 'simulation/'),\n",
     "                           url='https://github.com/YosefLab/scVI-data/raw/master/simulation/simulation_1.loom')\n",
     "\n",
     "scanvi = SCANVI(simulation_1.nb_genes, simulation_1.n_batches, simulation_1.n_labels)\n",
@@ -277,8 +267,8 @@
     }
    ],
    "source": [
-    "n_samples = 1000 if n_samples_tsne is None else n_samples_tsne\n",
-    "trainer_scanvi.full_dataset.show_t_sne(n_samples=n_samples, color_by='batches and labels')"
+    "n_samples_tsne = 1000\n",
+    "trainer_scanvi.full_dataset.show_t_sne(n_samples=n_samples_tsne, color_by='batches and labels')"
    ]
   },
   {
@@ -307,8 +297,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "M_sampling = 100 if M_sampling_all is None else M_sampling_all\n",
-    "M_permutation = 10000 if M_permutation_all is None else M_permutation_all\n",
+    "M_sampling = 100\n",
+    "M_permutation = 10000\n",
     "bayes_factors_list = trainer_scanvi.full_dataset.differential_expression_score(\n",
     "    'type1', 'type5', M_sampling=M_sampling, M_permutation=M_permutation\n",
     ")"
@@ -331,7 +321,7 @@
    "source": [
     "n_epochs_vae = 150 if n_epochs_all is None else n_epochs_all\n",
     "n_epochs_scanvi = 50 if n_epochs_all is None else n_epochs_all\n",
-    "n_samples = 1000 if n_samples_tsne is None else n_samples_tsne\n",
+    "n_samples_tsne = 1000 \n",
     "\n",
     "def scanvi_both_ways(dataset):\n",
     "    print(\"Unsupervised training: warm-up phase using only the VAE.\")\n",
@@ -339,7 +329,7 @@
     "    trainer = UnsupervisedTrainer(vae, dataset, train_size=1.0)\n",
     "    trainer.train(n_epochs_vae)\n",
     "    print(\"Entropy batch mixing : \", trainer.train_set.entropy_batch_mixing())\n",
-    "    trainer.train_set.show_t_sne(n_samples=n_samples, color_by='batches and labels')\n",
+    "    trainer.train_set.show_t_sne(n_samples=n_samples_tsne, color_by='batches and labels')\n",
     "\n",
     "    for i in [0,1]:\n",
     "        print(\"\\nUsing batch %d as labelled set\"%i)\n",
@@ -548,7 +538,7 @@
     "use_cuda=True\n",
     "\n",
     "n_epochs = 100 if n_epochs_all is None else n_epochs_all\n",
-    "n_cl =  10 if n_labelled_samples_per_class is None else n_labelled_samples_per_class\n",
+    "n_cl = 10\n",
     "scanvi = SCANVI(gene_dataset.nb_genes, gene_dataset.n_batches, gene_dataset.n_labels)\n",
     "trainer = JointSemiSupervisedTrainer(scanvi, gene_dataset, \n",
     "                                     n_labelled_samples_per_class=n_cl, \n",

--- a/tests/notebooks/annotation.ipynb
+++ b/tests/notebooks/annotation.ipynb
@@ -45,19 +45,13 @@
    ],
    "source": [
     "import os\n",
-    "import json\n",
-    "with open('tests/notebooks/annotation.config.json') as f:\n",
-    "    config = json.load(f)\n",
-    "print(config)\n",
     "\n",
-    "n_epochs_all = config['n_epochs'] if 'n_epochs' in config else None\n",
-    "save_path = config['save_path'] if 'save_path' in config else 'data/'\n",
-    "n_samples_tsne = config['n_samples_tsne'] if 'n_samples_tsne' in config else None\n",
-    "n_samples_posterior_density = config['n_samples_posterior_density'] if 'n_samples_posterior_density' in config else None\n",
-    "train_size = config['train_size'] if 'train_size' in config else None\n",
-    "M_sampling_all = config['M_sampling'] if 'M_sampling' in config else None\n",
-    "M_permutation_all = config['M_permutation'] if 'M_permutation' in config else None\n",
-    "n_labelled_samples_per_class = config['n_labelled_samples_per_class'] if 'n_labelled_samples_per_class' in config else None"
+    "save_path = 'data/'\n",
+    "n_epochs_all = None\n",
+    "n_labelled_samples_per_class = None\n",
+    "M_sampling_all = None\n",
+    "M_permutation_all = None\n",
+    "n_samples_tsne = None"
    ]
   },
   {
@@ -66,6 +60,12 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "assert n_samples_tsne == 10\n",
+    "assert n_epochs_all == 1\n",
+    "assert n_labelled_samples_per_class == 3\n",
+    "assert M_sampling_all == 1\n",
+    "assert M_permutation_all == 10\n",
+    "\n",
     "import numpy as np\n",
     "import matplotlib.pyplot as plt\n",
     "from scvi.dataset import CortexDataset, LoomDataset\n",

--- a/tests/notebooks/basic_tutorial.config.json
+++ b/tests/notebooks/basic_tutorial.config.json
@@ -1,3 +1,0 @@
-{
-    "save_path": "data/"
-}

--- a/tests/notebooks/basic_tutorial.ipynb
+++ b/tests/notebooks/basic_tutorial.ipynb
@@ -47,11 +47,7 @@
    ],
    "source": [
     "n_epochs_all = None\n",
-    "save_path = 'data/'\n",
-    "n_samples_tsne = None\n",
-    "train_size = None\n",
-    "M_sampling_all = None\n",
-    "M_permutation_all = None"
+    "save_path = 'data/'"
    ]
   },
   {
@@ -61,14 +57,10 @@
    "outputs": [],
    "source": [
     "import os\n",
-    "\n",
     "import numpy as np\n",
     "from sklearn.manifold import TSNE\n",
     "import matplotlib.pyplot as plt\n",
-    "\n",
-    "\n",
     "from scvi.dataset import CortexDataset, RetinaDataset\n",
-    "\n",
     "from scvi.models import *\n",
     "from scvi.inference import UnsupervisedTrainer"
    ]
@@ -158,7 +150,7 @@
     "vae = VAE(gene_dataset.nb_genes, n_batch=gene_dataset.n_batches * use_batches)\n",
     "trainer = UnsupervisedTrainer(vae,\n",
     "                              gene_dataset,\n",
-    "                              train_size=0.75 if train_size is None else train_size,\n",
+    "                              train_size=0.75,\n",
     "                              use_cuda=use_cuda,\n",
     "                              frequency=5)\n",
     "trainer.train(n_epochs=n_epochs, lr=lr)"
@@ -221,7 +213,7 @@
     }
    ],
    "source": [
-    "n_samples_tsne = 1000 if n_samples_tsne is None else n_samples_tsne\n",
+    "n_samples_tsne = 1000\n",
     "trainer.train_set.show_t_sne(n_samples=n_samples_tsne, color_by='labels')"
    ]
   },
@@ -312,7 +304,7 @@
     "vae = VAE(gene_dataset.nb_genes, n_batch=gene_dataset.n_batches * use_batches)\n",
     "trainer = UnsupervisedTrainer(vae,\n",
     "                              gene_dataset,\n",
-    "                              train_size=0.75 if train_size is None else train_size,\n",
+    "                              train_size=0.75,\n",
     "                              use_cuda=use_cuda)\n",
     "\n",
     "trainer.corrupt_posteriors(rate=0.1, corruption=\"uniform\")\n",
@@ -484,9 +476,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "M_sampling = 100 if M_sampling_all is None else M_sampling_all\n",
+    "M_sampling = 100\n",
     "\n",
-    "M_permutation = 100000  if M_permutation_all is None else M_permutation_all\n",
+    "M_permutation = 100000\n",
     "permutation = False"
    ]
   },
@@ -762,7 +754,7 @@
     "vae = VAE(gene_dataset.nb_genes, n_batch=gene_dataset.n_batches * use_batches)\n",
     "trainer = UnsupervisedTrainer(vae, \n",
     "                              gene_dataset, \n",
-    "                              train_size=0.9 if train_size is None else train_size, \n",
+    "                              train_size=0.9, \n",
     "                              use_cuda=use_cuda,\n",
     "                              frequency=5)\n",
     "trainer.train(n_epochs=n_epochs, lr=lr)"
@@ -845,7 +837,7 @@
    ],
    "source": [
     "# obtaining latent space in the same order as the input data\n",
-    "n_samples_tsne = 1000 if n_samples_tsne is None else n_samples_tsne\n",
+    "n_samples_tsne = 1000\n",
     "trainer.train_set.show_t_sne(n_samples=n_samples_tsne, color_by='batches and labels')"
    ]
   },

--- a/tests/notebooks/basic_tutorial.ipynb
+++ b/tests/notebooks/basic_tutorial.ipynb
@@ -46,19 +46,12 @@
     }
    ],
    "source": [
-    "import json\n",
-    "with open('tests/notebooks/basic_tutorial.config.json') as f:\n",
-    "    config = json.load(f)\n",
-    "print(config)\n",
-    "\n",
-    "n_epochs_all = config['n_epochs'] if 'n_epochs' in config else None\n",
-    "save_path = config['save_path'] if 'save_path' in config else 'data/'\n",
-    "n_samples_tsne = config['n_samples_tsne'] if 'n_samples_tsne' in config else None\n",
-    "n_samples_posterior_density = config['n_samples_posterior_density'] if 'n_samples_posterior_density' in config else None\n",
-    "train_size = config['train_size'] if 'train_size' in config else None\n",
-    "M_sampling_all = config['M_sampling'] if 'M_sampling' in config else None\n",
-    "M_permutation_all = config['M_permutation'] if 'M_permutation' in config else None\n",
-    "rate = config['rate'] if 'rate' in config else None"
+    "n_epochs_all = None\n",
+    "save_path = 'data/'\n",
+    "n_samples_tsne = None\n",
+    "train_size = None\n",
+    "M_sampling_all = None\n",
+    "M_permutation_all = None"
    ]
   },
   {
@@ -165,7 +158,7 @@
     "vae = VAE(gene_dataset.nb_genes, n_batch=gene_dataset.n_batches * use_batches)\n",
     "trainer = UnsupervisedTrainer(vae,\n",
     "                              gene_dataset,\n",
-    "                              train_size=0.75,\n",
+    "                              train_size=0.75 if train_size is None else train_size,\n",
     "                              use_cuda=use_cuda,\n",
     "                              frequency=5)\n",
     "trainer.train(n_epochs=n_epochs, lr=lr)"
@@ -228,6 +221,7 @@
     }
    ],
    "source": [
+    "n_samples_tsne = 1000 if n_samples_tsne is None else n_samples_tsne\n",
     "trainer.train_set.show_t_sne(n_samples=n_samples_tsne, color_by='labels')"
    ]
   },
@@ -768,7 +762,7 @@
     "vae = VAE(gene_dataset.nb_genes, n_batch=gene_dataset.n_batches * use_batches)\n",
     "trainer = UnsupervisedTrainer(vae, \n",
     "                              gene_dataset, \n",
-    "                              train_size=0.9, \n",
+    "                              train_size=0.9 if train_size is None else train_size, \n",
     "                              use_cuda=use_cuda,\n",
     "                              frequency=5)\n",
     "trainer.train(n_epochs=n_epochs, lr=lr)"
@@ -851,6 +845,7 @@
    ],
    "source": [
     "# obtaining latent space in the same order as the input data\n",
+    "n_samples_tsne = 1000 if n_samples_tsne is None else n_samples_tsne\n",
     "trainer.train_set.show_t_sne(n_samples=n_samples_tsne, color_by='batches and labels')"
    ]
   },

--- a/tests/notebooks/data_loading.config.json
+++ b/tests/notebooks/data_loading.config.json
@@ -1,3 +1,0 @@
-{
-    "save_path": "data/"
-}

--- a/tests/notebooks/data_loading.ipynb
+++ b/tests/notebooks/data_loading.ipynb
@@ -32,12 +32,7 @@
    },
    "outputs": [],
    "source": [
-    "import json\n",
-    "with open('tests/notebooks/data_loading.config.json') as f:\n",
-    "    config = json.load(f)\n",
-    "print(config)\n",
-    "\n",
-    "save_path = config['save_path'] if 'save_path' in config else 'data/'"
+    "save_path = 'data/'"
    ]
   },
   {

--- a/tests/notebooks/scRNA_and_smFISH.config.json
+++ b/tests/notebooks/scRNA_and_smFISH.config.json
@@ -1,3 +1,0 @@
-{
-    "save_path": "data/"
-}

--- a/tests/notebooks/scRNA_and_smFISH.ipynb
+++ b/tests/notebooks/scRNA_and_smFISH.ipynb
@@ -57,19 +57,10 @@
     }
    ],
    "source": [
-    "import json\n",
-    "with open('tests/notebooks/scRNA_and_smFISH.config.json') as f:\n",
-    "    config = json.load(f)\n",
-    "print(config)\n",
-    "\n",
-    "n_epochs_all = config['n_epochs'] if 'n_epochs' in config else None\n",
-    "save_path = config['save_path'] if 'save_path' in config else 'data/'\n",
-    "n_samples_tsne = config['n_samples_tsne'] if 'n_samples_tsne' in config else None\n",
-    "n_samples_posterior_density = config['n_samples_posterior_density'] if 'n_samples_posterior_density' in config else None\n",
-    "train_size = config['train_size'] if 'train_size' in config else None\n",
-    "M_sampling = config['M_sampling'] if 'M_sampling' in config else None\n",
-    "M_permutation = config['M_permutation'] if 'M_permutation' in config else None\n",
-    "rate = config['rate'] if 'rate' in config else None"
+    "n_epochs_all = None\n",
+    "save_path = 'data/'\n",
+    "n_samples_tsne = None\n",
+    "train_size = None"
    ]
   },
   {
@@ -496,7 +487,8 @@
    "outputs": [],
    "source": [
     "from sklearn.manifold import TSNE\n",
-    "def get_common_t_sne(latent_seq, latent_fish, n_samples=1000):\n",
+    "n_samples_tsne = 1000 if n_samples_tsne is None else n_samples_tsne\n",
+    "def get_common_t_sne(latent_seq, latent_fish, n_samples=n_samples_tsne):\n",
     "    idx_t_sne_a = np.random.permutation(len(latent_seq))[:n_samples]\n",
     "    idx_t_sne_b = np.random.permutation(len(latent_fish))[:n_samples]\n",
     "    full_latent = np.concatenate((latent_seq[idx_t_sne_a, :], latent_fish[idx_t_sne_b, :]))\n",

--- a/tests/notebooks/scRNA_and_smFISH.ipynb
+++ b/tests/notebooks/scRNA_and_smFISH.ipynb
@@ -58,9 +58,7 @@
    ],
    "source": [
     "n_epochs_all = None\n",
-    "save_path = 'data/'\n",
-    "n_samples_tsne = None\n",
-    "train_size = None"
+    "save_path = 'data/'"
    ]
   },
   {
@@ -160,10 +158,12 @@
    ],
    "source": [
     "n_epochs = 50 if n_epochs_all is None else n_epochs_all\n",
+    "train_size = 0.9\n",
     "vae = VAEF(gene_dataset_seq.nb_genes, indexes_to_keep, n_layers_decoder=1, n_latent=8,\n",
-    "           n_layers=1, n_hidden=256, reconstruction_loss='nb', dropout_rate=0.3, n_labels=7, n_batch=2, model_library=False)\n",
-    "trainer = TrainerFish(vae, gene_dataset_seq, gene_dataset_fish, train_size=0.9, verbose=False, frequency=5, weight_decay=0.30, n_epochs_even=1, n_epochs_kl=1000,\n",
-    "                                cl_ratio = 30, n_epochs_cl=150)\n",
+    "           n_layers=1, n_hidden=256, reconstruction_loss='nb', dropout_rate=0.3, n_labels=7, n_batch=2, \n",
+    "           model_library=False)\n",
+    "trainer = TrainerFish(vae, gene_dataset_seq, gene_dataset_fish, train_size=train_size, verbose=False, frequency=5, \n",
+    "                      weight_decay=0.30, n_epochs_even=1, n_epochs_kl=1000, cl_ratio = 30, n_epochs_cl=150)\n",
     "trainer.train(n_epochs=n_epochs, lr=0.001)\n",
     "data_loader_fish = trainer.train_fish\n",
     "data_loader_seq = trainer.train_seq"
@@ -487,7 +487,7 @@
    "outputs": [],
    "source": [
     "from sklearn.manifold import TSNE\n",
-    "n_samples_tsne = 1000 if n_samples_tsne is None else n_samples_tsne\n",
+    "n_samples_tsne = 1000\n",
     "def get_common_t_sne(latent_seq, latent_fish, n_samples=n_samples_tsne):\n",
     "    idx_t_sne_a = np.random.permutation(len(latent_seq))[:n_samples]\n",
     "    idx_t_sne_b = np.random.permutation(len(latent_fish))[:n_samples]\n",
@@ -497,7 +497,8 @@
     "    if latent.shape[0] != len(idx_t_sne_a) + len(idx_t_sne_b):\n",
     "        print(\"Be careful! There might be a mistake in the downsampling of the data points\")\n",
     "    return latent[:len(idx_t_sne_a), :], latent[len(idx_t_sne_a):, :], idx_t_sne_a, idx_t_sne_b\n",
-    "t_sne_seq, t_sne_fish, idx_t_sne_seq, idx_t_sne_fish = get_common_t_sne(latent_seq, latent_fish, n_samples=1000)"
+    "t_sne_seq, t_sne_fish, idx_t_sne_seq, idx_t_sne_fish = get_common_t_sne(latent_seq, latent_fish, \n",
+    "                                                                        n_samples=n_samples_tsne)"
    ]
   },
   {

--- a/tests/notebooks/scVI_reproducibility.config.json
+++ b/tests/notebooks/scVI_reproducibility.config.json
@@ -1,3 +1,0 @@
-{
-    "save_path": "data/"
-}

--- a/tests/notebooks/scVI_reproducibility.ipynb
+++ b/tests/notebooks/scVI_reproducibility.ipynb
@@ -64,19 +64,14 @@
     }
    ],
    "source": [
-    "import json\n",
-    "with open('tests/notebooks/scVI_reproducibility.config.json') as f:\n",
-    "    config = json.load(f)\n",
-    "print(config)\n",
-    "\n",
-    "n_epochs_all = config['n_epochs'] if 'n_epochs' in config else None\n",
-    "save_path = config['save_path'] if 'save_path' in config else 'data/'\n",
-    "n_samples_tsne = config['n_samples_tsne'] if 'n_samples_tsne' in config else None\n",
-    "n_samples_posterior_density = config['n_samples_posterior_density'] if 'n_samples_posterior_density' in config else None\n",
-    "train_size = config['train_size'] if 'train_size' in config else None\n",
-    "M_sampling = config['M_sampling'] if 'M_sampling' in config else None\n",
-    "M_permutation = config['M_permutation'] if 'M_permutation' in config else None\n",
-    "rate = config['rate'] if 'rate' in config else None"
+    "n_epochs_all = None\n",
+    "save_path = 'data/'\n",
+    "n_samples_tsne = None\n",
+    "n_samples_posterior_density = None\n",
+    "train_size = None\n",
+    "M_sampling = None\n",
+    "M_permutation = None\n",
+    "rate = None"
    ]
   },
   {
@@ -395,6 +390,7 @@
     }
    ],
    "source": [
+    "n_samples_tsne = 1000 if n_samples_tsne is None else n_samples_tsne\n",
     "trainer_cortex.train_set.show_t_sne(n_samples=n_samples_tsne, color_by='labels')"
    ]
   },
@@ -893,7 +889,7 @@
    "source": [
     "# set hyperparameters \n",
     "from scvi.inference import UnsupervisedTrainer\n",
-    "n_epochs=1 if n_epochs_all is None else n_epochs_all\n",
+    "n_epochs=1\n",
     "lr=0.0004\n",
     "use_batches=False\n",
     "use_cuda=True\n",
@@ -931,9 +927,11 @@
     "pbmc_trainer.selected_posterior_BDC = pbmc_trainer.create_posterior(\n",
     "    indices=np.concatenate((cell_a_idx, cell_b_idx))\n",
     ")\n",
+    "M_sampling = 300 if M_sampling is None else M_sampling\n",
+    "M_permutation = 40000 if M_permutation is None else M_permutation\n",
     "st = pbmc_trainer.selected_posterior_BDC.differential_expression_score('Dendritic Cells', 'B cells',\n",
-    "                                                                   M_sampling=300 if M_sampling is None else M_sampling, \n",
-    "                                                                   M_permutation=40000 if M_permutation is None else M_permutation)"
+    "                                                                   M_sampling=M_sampling, \n",
+    "                                                                   M_permutation=M_permutation)"
    ]
   },
   {
@@ -2024,7 +2022,10 @@
     "cell_a_idx = np.random.choice(np.where((pbmc_dataset.labels==3).ravel())[0], 100)\n",
     "cell_b_idx = np.random.choice(np.where((pbmc_dataset.labels==2).ravel())[0], 100)\n",
     "pbmc_trainer.selected_posterior_CD = pbmc_trainer.create_posterior(indices=np.concatenate((cell_a_idx, cell_b_idx)))\n",
-    "st = pbmc_trainer.selected_posterior_CD.differential_expression_score(3,2,M_sampling=200, M_permutation=40000)\n",
+    "M_sampling = 200 if M_sampling is None else M_sampling\n",
+    "M_permutation = 40000 if M_permutation is None else M_permutation\n",
+    "st = pbmc_trainer.selected_posterior_CD.differential_expression_score(3,2,M_sampling=M_sampling, \n",
+    "                                                                      M_permutation=M_permutation)\n",
     "\n",
     "plt.figure(figsize=(5, 5))\n",
     "plt.scatter(st, signed_p_value)\n",
@@ -2071,7 +2072,10 @@
     "cell_a_idx = np.random.choice(np.where((pbmc_dataset.labels==2).ravel())[0], 100)\n",
     "cell_b_idx = np.random.choice(np.where((pbmc_dataset.labels==2).ravel())[0], 100)\n",
     "pbmc_trainer.selected_posterior_CD = pbmc_trainer.create_posterior(indices=np.concatenate((cell_a_idx, cell_b_idx)))\n",
-    "st = pbmc_trainer.selected_posterior_CD.differential_expression_score(2,2,M_sampling=200, M_permutation=40000)\n",
+    "M_sampling = 200 if M_sampling is None else M_sampling\n",
+    "M_permutation = 40000 if M_permutation is None else M_permutation\n",
+    "st = pbmc_trainer.selected_posterior_CD.differential_expression_score(2,2,M_sampling=M_sampling, \n",
+    "                                                                      M_permutation=M_permutation)\n",
     "\n",
     "plt.figure(figsize=(5, 5))\n",
     "plt.hist(st, density=True)\n",

--- a/tests/notebooks/scVI_reproducibility.ipynb
+++ b/tests/notebooks/scVI_reproducibility.ipynb
@@ -65,13 +65,7 @@
    ],
    "source": [
     "n_epochs_all = None\n",
-    "save_path = 'data/'\n",
-    "n_samples_tsne = None\n",
-    "n_samples_posterior_density = None\n",
-    "train_size = None\n",
-    "M_sampling = None\n",
-    "M_permutation = None\n",
-    "rate = None"
+    "save_path = 'data/'"
    ]
   },
   {
@@ -81,17 +75,13 @@
    "outputs": [],
    "source": [
     "import os\n",
-    "\n",
     "import numpy as np\n",
     "import pandas as pd\n",
     "from sklearn.manifold import TSNE\n",
     "import matplotlib.pyplot as plt\n",
     "from matplotlib import gridspec\n",
-    "\n",
     "from scvi.dataset import GeneExpressionDataset, CortexDataset, RetinaDataset, BrainLargeDataset, HematoDataset, CbmcDataset, SyntheticDataset, SyntheticRandomDataset, PbmcDataset, BrainSmallDataset\n",
-    "\n",
     "from scvi.models import VAE\n",
-    "\n",
     "from scvi.inference import UnsupervisedTrainer, AdapterTrainer"
    ]
   },
@@ -183,7 +173,7 @@
     "    brainlarge_vae = VAE(brainlarge_dataset.nb_genes, n_batch=brainlarge_dataset.n_batches * use_batches) \n",
     "    brainlarge_trainer = UnsupervisedTrainer(brainlarge_vae,\n",
     "                                           brainlarge_dataset,\n",
-    "                                           train_size=0.9 if train_size is None else train_size,\n",
+    "                                           train_size=0.9,\n",
     "                                           use_cuda=use_cuda)\n",
     "    %time brainlarge_trainer.train(n_epochs=n_epochs, lr=lr)"
    ]
@@ -262,11 +252,10 @@
     "n_cells_list = [100000, 50000, 30000, 15000, 10000, 4000]\n",
     "for n_cells in n_cells_list:\n",
     "    brainlarge_dataset.subsample_cells(n_cells) \n",
-    "    \n",
     "    brainlarge_vae = VAE(brainlarge_dataset.nb_genes, n_batch=brainlarge_dataset.n_batches * use_batches) \n",
     "    brainlarge_trainer = UnsupervisedTrainer(brainlarge_vae,\n",
     "                                             brainlarge_dataset,\n",
-    "                                             train_size=0.5 if train_size is None else train_size,\n",
+    "                                             train_size=0.5,\n",
     "                                             use_cuda=use_cuda) \n",
     "    %time brainlarge_trainer.train(n_epochs=n_epochs, lr=lr)\n",
     "    adapter_brainlarge_trainer = AdapterTrainer(brainlarge_vae,brainlarge_dataset, brainlarge_trainer.test_set)\n",
@@ -390,7 +379,7 @@
     }
    ],
    "source": [
-    "n_samples_tsne = 1000 if n_samples_tsne is None else n_samples_tsne\n",
+    "n_samples_tsne = 1000\n",
     "trainer_cortex.train_set.show_t_sne(n_samples=n_samples_tsne, color_by='labels')"
    ]
   },
@@ -493,7 +482,7 @@
     "hemato_vae = VAE(hemato_dataset.nb_genes, n_batch=hemato_dataset.n_batches * use_batches)\n",
     "hemato_trainer = UnsupervisedTrainer(hemato_vae,\n",
     "                                     hemato_dataset,\n",
-    "                                     train_size=0.9 if train_size is None else train_size, \n",
+    "                                     train_size=0.9, \n",
     "                                     use_cuda=use_cuda, \n",
     "                                     frequency=5)\n",
     "hemato_trainer.train(n_epochs=n_epochs, lr=lr)"
@@ -927,8 +916,8 @@
     "pbmc_trainer.selected_posterior_BDC = pbmc_trainer.create_posterior(\n",
     "    indices=np.concatenate((cell_a_idx, cell_b_idx))\n",
     ")\n",
-    "M_sampling = 300 if M_sampling is None else M_sampling\n",
-    "M_permutation = 40000 if M_permutation is None else M_permutation\n",
+    "M_sampling = 300\n",
+    "M_permutation = 40000\n",
     "st = pbmc_trainer.selected_posterior_BDC.differential_expression_score('Dendritic Cells', 'B cells',\n",
     "                                                                   M_sampling=M_sampling, \n",
     "                                                                   M_permutation=M_permutation)"
@@ -1348,8 +1337,8 @@
     "trainer_cortex.train(n_epochs=n_epochs)\n",
     "\n",
     "\n",
-    "n_samples=30 if n_samples_posterior_density is None else n_samples_posterior_density # 250 is scVI-reproducibility\n",
-    "x, y = trainer_cortex.train_set.generate(genes=['FAU'], n_samples=n_samples) \n",
+    "n_samples_posterior_density=30 # 250 is scVI-reproducibility\n",
+    "x, y = trainer_cortex.train_set.generate(genes=['FAU'], n_samples=n_samples_posterior_density) \n",
     "# \"THY1\" ?  253 => FAU in gene names index\n",
     "\n",
     "x = x.squeeze()\n",
@@ -2022,8 +2011,8 @@
     "cell_a_idx = np.random.choice(np.where((pbmc_dataset.labels==3).ravel())[0], 100)\n",
     "cell_b_idx = np.random.choice(np.where((pbmc_dataset.labels==2).ravel())[0], 100)\n",
     "pbmc_trainer.selected_posterior_CD = pbmc_trainer.create_posterior(indices=np.concatenate((cell_a_idx, cell_b_idx)))\n",
-    "M_sampling = 200 if M_sampling is None else M_sampling\n",
-    "M_permutation = 40000 if M_permutation is None else M_permutation\n",
+    "M_sampling = 200\n",
+    "M_permutation = 40000\n",
     "st = pbmc_trainer.selected_posterior_CD.differential_expression_score(3,2,M_sampling=M_sampling, \n",
     "                                                                      M_permutation=M_permutation)\n",
     "\n",
@@ -2072,8 +2061,8 @@
     "cell_a_idx = np.random.choice(np.where((pbmc_dataset.labels==2).ravel())[0], 100)\n",
     "cell_b_idx = np.random.choice(np.where((pbmc_dataset.labels==2).ravel())[0], 100)\n",
     "pbmc_trainer.selected_posterior_CD = pbmc_trainer.create_posterior(indices=np.concatenate((cell_a_idx, cell_b_idx)))\n",
-    "M_sampling = 200 if M_sampling is None else M_sampling\n",
-    "M_permutation = 40000 if M_permutation is None else M_permutation\n",
+    "M_sampling = 200\n",
+    "M_permutation = 40000\n",
     "st = pbmc_trainer.selected_posterior_CD.differential_expression_score(2,2,M_sampling=M_sampling, \n",
     "                                                                      M_permutation=M_permutation)\n",
     "\n",
@@ -2369,12 +2358,13 @@
     "    results[d] = []\n",
     "    for _ in range(n_trials):\n",
     "        vae = VAE(gene_dataset.nb_genes, n_batch=gene_dataset.n_batches * use_batches, n_latent=d)\n",
+    "        train_size = min(10000, gene_dataset.X.shape[0]-1)\n",
     "        trainer = UnsupervisedTrainer(vae,\n",
     "                                      gene_dataset,\n",
-    "                                      train_size=10000 if train_size is None else train_size,\n",
+    "                                      train_size=train_size,\n",
     "                                      use_cuda=use_cuda)\n",
     "\n",
-    "        trainer.corrupt_posteriors(rate=.1 if rate is None else rate, corruption=\"uniform\")\n",
+    "        trainer.corrupt_posteriors(rate=.1, corruption=\"uniform\")\n",
     "        trainer.train(n_epochs)\n",
     "        trainer.uncorrupt_posteriors()\n",
     "        \n",
@@ -2436,16 +2426,15 @@
     "\n",
     "trainer_brain_large = UnsupervisedTrainer(vae, brain_large_dataset, frequency=1)\n",
     "\n",
-    "train_size_brain_large = 10000 if train_size is None else 2\n",
+    "train_size_brain_large = 10000 if n_epochs_all is None else 2\n",
     "trainer_brain_large.train_set = trainer_brain_large.create_posterior(indices=np.arange(train_size_brain_large))\n",
     "trainer_brain_large.test_set = trainer_brain_large.create_posterior(indices=np.arange(train_size_brain_large,2*train_size_brain_large))\n",
     "trainer_brain_large.train_set.to_monitor = ['imputation_score', 'll']\n",
     "trainer_brain_large.test_set.to_monitor = ['ll']\n",
     "n_epoch = 120 if n_epochs_all is None else n_epochs_all\n",
     "\n",
-    "trainer_brain_large.corrupt_posteriors(rate=0.2 if rate is None else rate, corruption=\"binomial\")\n",
+    "trainer_brain_large.corrupt_posteriors(rate=0.2, corruption=\"binomial\")\n",
     "# gene_dataset.corrupted_X = np.ascontiguousarray(gene_dataset.corrupted_X.A, dtype=np.float32)\n",
-    "\n",
     "trainer_brain_large.train(n_epoch)\n",
     "trainer_brain_large.uncorrupt_posteriors()"
    ]
@@ -2718,7 +2707,8 @@
     "hemato_trainer.train(n_epochs=n_epochs, lr=lr)\n",
     "# visualize latent space \n",
     "hemato_trainer.full_dataset = hemato_trainer.create_posterior(shuffle=False)\n",
-    "latent_hemato, _ = hemato_trainer.full_dataset.apply_t_sne(hemato_trainer.full_dataset.get_latent()[0],n_samples = None)"
+    "latent_hemato, _ = hemato_trainer.full_dataset.apply_t_sne(hemato_trainer.full_dataset.get_latent()[0], \n",
+    "                                                           n_samples = None)"
    ]
   },
   {

--- a/tests/test_notebook.py
+++ b/tests/test_notebook.py
@@ -110,8 +110,6 @@ class NotebookFinder(object):
 
 sys.meta_path.append(NotebookFinder())
 
-path = 'tests/notebooks/'
-
 
 def test_notebooks(save_path):
     pickle.dump(save_path, open('tests/data/path_test', 'wb'))

--- a/tests/test_notebook.py
+++ b/tests/test_notebook.py
@@ -71,13 +71,12 @@ class NotebookLoader(object):
                         code = self.shell.input_transformer_manager.transform_cell(cell.source)
                         # replace parameters with test parameters to run faster
                         code = re.sub("n_epochs_all = None", "n_epochs_all = 1", code)
-                        code = re.sub("n_labelled_samples_per_class = None", "n_labelled_samples_per_class = 3", code)
-                        code = re.sub("M_permutation_all = None", "M_permutation_all = 10", code)
-                        code = re.sub("M_sampling_all = None", "M_sampling_all = 1", code)
-                        code = re.sub("n_samples_tsne = None", "n_samples_tsne = 10", code)
-                        code = re.sub("n_samples_posterior_density = None", "n_samples_posterior_density = 2", code)
+                        code = re.sub("n_cl = \d+", "n_cl = 3", code)
+                        code = re.sub("M_permutation = \d+", "M_permutation = 10", code)
+                        code = re.sub("M_sampling = \d+", "M_sampling = 1", code)
+                        code = re.sub("n_samples_tsne = \d+", "n_samples_tsne = 10", code)
+                        code = re.sub("n_samples_posterior_density = \d+", "n_samples_posterior_density = 2", code)
                         code = re.sub("save_path = 'data/'", "save_path = '"+save_path+"'", code)
-                        code = re.sub("train_size = None", "train_size = 0.5", code)
                         # run the code in themodule
                         exec(code, mod.__dict__)
                         plt.close('all')

--- a/tests/test_notebook.py
+++ b/tests/test_notebook.py
@@ -5,9 +5,8 @@ from IPython import get_ipython
 from nbformat import read
 from IPython.core.interactiveshell import InteractiveShell
 import os
-import shutil
 import matplotlib.pyplot as plt
-import json
+import pickle
 import re
 
 
@@ -61,6 +60,8 @@ class NotebookLoader(object):
         save_user_ns = self.shell.user_ns
         self.shell.user_ns = mod.__dict__
 
+        save_path = pickle.load(open('tests/data/path_test', 'rb'))
+
         try:
             i = 0
             for cell in nb.cells:
@@ -75,7 +76,7 @@ class NotebookLoader(object):
                         code = re.sub("M_sampling_all = None", "M_sampling_all = 1", code)
                         code = re.sub("n_samples_tsne = None", "n_samples_tsne = 10", code)
                         code = re.sub("n_samples_posterior_density = None", "n_samples_posterior_density = 2", code)
-                        code = re.sub("save_path = 'data/", "save_path = 'tests/data/", code)
+                        code = re.sub("save_path = 'data/'", "save_path = '"+save_path+"'", code)
                         code = re.sub("train_size = None", "train_size = 0.5", code)
                         # run the code in themodule
                         exec(code, mod.__dict__)
@@ -112,33 +113,32 @@ sys.meta_path.append(NotebookFinder())
 path = 'tests/notebooks/'
 
 
-def test_notebooks():
-    prefix = 'annotation'
+def test_notebooks(save_path):
+    pickle.dump(save_path, open('tests/data/path_test', 'wb'))
 
-    import notebooks.annotation
-    notebooks.annotation.allow_notebook_for_test()
-    plt.close('all')
+    try:
+        import notebooks.annotation
+        notebooks.annotation.allow_notebook_for_test()
+        plt.close('all')
 
-    prefix = 'scRNA_and_smFISH'
+        import notebooks.scRNA_and_smFISH
+        notebooks.scRNA_and_smFISH.allow_notebook_for_test()
+        plt.close('all')
 
-    import notebooks.scRNA_and_smFISH
-    notebooks.scRNA_and_smFISH.allow_notebook_for_test()
-    plt.close('all')
+        import notebooks.data_loading
+        notebooks.data_loading.allow_notebook_for_test()
+        plt.close('all')
 
-    prefix = 'data_loading'
+        import notebooks.basic_tutorial
+        notebooks.basic_tutorial.allow_notebook_for_test()
+        plt.close('all')
 
-    import notebooks.data_loading
-    notebooks.data_loading.allow_notebook_for_test()
-    plt.close('all')
+        import notebooks.scVI_reproducibility
+        notebooks.scVI_reproducibility.allow_notebook_for_test()
+        plt.close('all')
 
-    prefix = 'basic_tutorial'
+    except BaseException:
+        raise
 
-    import notebooks.basic_tutorial
-    notebooks.basic_tutorial.allow_notebook_for_test()
-    plt.close('all')
-
-    prefix = 'scVI_reproducibility'
-
-    import notebooks.scVI_reproducibility
-    notebooks.scVI_reproducibility.allow_notebook_for_test()
-    plt.close('all')
+    finally:
+        os.remove('tests/data/path_test')

--- a/tests/test_notebook.py
+++ b/tests/test_notebook.py
@@ -8,6 +8,7 @@ import os
 import shutil
 import matplotlib.pyplot as plt
 import json
+import re
 
 
 def find_notebook(fullname, path=None):
@@ -67,6 +68,15 @@ class NotebookLoader(object):
                     if i != 0:  # the first code cell is cd ../.. which is not needed here and would generate errors
                         # transform the input to executable Python
                         code = self.shell.input_transformer_manager.transform_cell(cell.source)
+                        # replace parameters with test parameters to run faster
+                        code = re.sub("n_epochs_all = None", "n_epochs_all = 1", code)
+                        code = re.sub("n_labelled_samples_per_class = None", "n_labelled_samples_per_class = 3", code)
+                        code = re.sub("M_permutation_all = None", "M_permutation_all = 10", code)
+                        code = re.sub("M_sampling_all = None", "M_sampling_all = 1", code)
+                        code = re.sub("n_samples_tsne = None", "n_samples_tsne = 10", code)
+                        code = re.sub("n_samples_posterior_density = None", "n_samples_posterior_density = 2", code)
+                        code = re.sub("save_path = 'data/", "save_path = 'tests/data/", code)
+                        code = re.sub("train_size = None", "train_size = 0.5", code)
                         # run the code in themodule
                         exec(code, mod.__dict__)
                         plt.close('all')
@@ -100,152 +110,35 @@ class NotebookFinder(object):
 sys.meta_path.append(NotebookFinder())
 
 path = 'tests/notebooks/'
-test_path = 'tests/config_notebooks_tests/'
 
 
-def test_notebooks(save_path):
+def test_notebooks():
     prefix = 'annotation'
-    # if exists, save and overwrite
 
-    config_filename = prefix + '.config.json'  # By default, benchmark config, but overridden for tests
-    config_filename_tmp = prefix + '.config.tmp.json'
-
-    with open(test_path+config_filename, 'r') as f:
-        config_test = json.load(f)
-        config_test['save_path'] = save_path
-
-    with open(test_path+config_filename, 'w') as f:
-        json.dump(config_test, f)
-
-    # Save content in memory in tmp file
-    existing_config_to_restore = os.path.exists(path + config_filename)
-    if existing_config_to_restore:
-        shutil.copy(path + config_filename, path + config_filename_tmp)
-
-    # Overwritting
-    shutil.copy(test_path + config_filename, path + config_filename)
-    try:
-        import notebooks.annotation
-        notebooks.annotation.allow_notebook_for_test()
-        plt.close('all')
-    except BaseException:
-        raise
-    finally:
-        if existing_config_to_restore:
-            shutil.move(path + config_filename_tmp, path + config_filename)
+    import notebooks.annotation
+    notebooks.annotation.allow_notebook_for_test()
+    plt.close('all')
 
     prefix = 'scRNA_and_smFISH'
-    # if exists, save and overwrite
-    config_filename = prefix + '.config.json'  # By default, benchmark config, but overridden for tests
-    config_filename_tmp = prefix + '.config.tmp.json'
 
-    with open(test_path+config_filename, 'r') as f:
-        config_test = json.load(f)
-        config_test['save_path'] = save_path
-
-    with open(test_path+config_filename, 'w') as f:
-        json.dump(config_test, f)
-
-    # Save content in memory in tmp file
-    existing_config_to_restore = os.path.exists(path + config_filename)
-    if existing_config_to_restore:
-        shutil.copy(path + config_filename, path + config_filename_tmp)
-
-    # Overwritting
-    shutil.copy(test_path + config_filename, path + config_filename)
-    try:
-        import notebooks.scRNA_and_smFISH
-        notebooks.scRNA_and_smFISH.allow_notebook_for_test()
-        plt.close('all')
-    except BaseException:
-        raise
-    finally:
-        if existing_config_to_restore:
-            shutil.move(path + config_filename_tmp, path + config_filename)
+    import notebooks.scRNA_and_smFISH
+    notebooks.scRNA_and_smFISH.allow_notebook_for_test()
+    plt.close('all')
 
     prefix = 'data_loading'
-    # if exists, save and overwrite
-    config_filename = prefix + '.config.json'  # By default, benchmark config, but overridden for tests
-    config_filename_tmp = prefix + '.config.tmp.json'
 
-    with open(test_path+config_filename, 'r') as f:
-        config_test = json.load(f)
-        config_test['save_path'] = save_path
-
-    with open(test_path+config_filename, 'w') as f:
-        json.dump(config_test, f)
-
-    # Save content in memory in tmp file
-    existing_config_to_restore = os.path.exists(path + config_filename)
-    if existing_config_to_restore:
-        shutil.copy(path + config_filename, path + config_filename_tmp)
-
-    # Overwritting
-    shutil.copy(test_path + config_filename, path + config_filename)
-    try:
-        import notebooks.data_loading
-        notebooks.data_loading.allow_notebook_for_test()
-        plt.close('all')
-    except BaseException:
-        raise
-    finally:
-        if existing_config_to_restore:
-            shutil.move(path + config_filename_tmp, path + config_filename)
+    import notebooks.data_loading
+    notebooks.data_loading.allow_notebook_for_test()
+    plt.close('all')
 
     prefix = 'basic_tutorial'
-    # if exists, save and overwrite
-    config_filename = prefix + '.config.json'  # By default, benchmark config, but overridden for tests
-    config_filename_tmp = prefix + '.config.tmp.json'
 
-    with open(test_path+config_filename, 'r') as f:
-        config_test = json.load(f)
-        config_test['save_path'] = save_path
-
-    with open(test_path+config_filename, 'w') as f:
-        json.dump(config_test, f)
-
-    # Save content in memory in tmp file
-    existing_config_to_restore = os.path.exists(path + config_filename)
-    if existing_config_to_restore:
-        shutil.copy(path + config_filename, path + config_filename_tmp)
-
-    # Overwritting
-    shutil.copy(test_path + config_filename, path + config_filename)
-    try:
-        import notebooks.basic_tutorial
-        notebooks.basic_tutorial.allow_notebook_for_test()
-        plt.close('all')
-    except BaseException:
-        raise
-    finally:
-        if existing_config_to_restore:
-            shutil.move(path + config_filename_tmp, path + config_filename)
+    import notebooks.basic_tutorial
+    notebooks.basic_tutorial.allow_notebook_for_test()
+    plt.close('all')
 
     prefix = 'scVI_reproducibility'
-    # if exists, save and overwrite
-    config_filename = prefix + '.config.json'  # By default, benchmark config, but overridden for tests
-    config_filename_tmp = prefix + '.config.tmp.json'
 
-    with open(test_path+config_filename, 'r') as f:
-        config_test = json.load(f)
-        config_test['save_path'] = save_path
-
-    with open(test_path+config_filename, 'w') as f:
-        json.dump(config_test, f)
-
-    # Save content in memory in tmp file
-    existing_config_to_restore = os.path.exists(path + config_filename)
-    if existing_config_to_restore:
-        shutil.copy(path + config_filename, path + config_filename_tmp)
-
-    # Overwritting
-    shutil.copy(test_path + config_filename, path + config_filename)
-    try:
-        import notebooks.scVI_reproducibility
-        notebooks.scVI_reproducibility.allow_notebook_for_test()
-        plt.close('all')
-    except BaseException:
-        raise
-    finally:
-        if existing_config_to_restore:
-            shutil.move(path + config_filename_tmp, path + config_filename)
+    import notebooks.scVI_reproducibility
+    notebooks.scVI_reproducibility.allow_notebook_for_test()
+    plt.close('all')


### PR DESCRIPTION
Instead of having for each notebook two json configuration files containing the values of the parameters we use to run the notebooks (eg the path of the directory containing the datasets, the number of epochs, etc.) either for tests or outside of test sessions, we now modify the code of the notebooks when running them for tests. Inside `test_notebook.py` each notebook is tested by extracting the code from each of its cells and running this collected code. During that step we now replace, in the code extracted, the fragments of code where the parameters are defined  so that the code executed  by `test_notebook.py` has the 'test' parameters (few epochs, small subsampled datasets so that tests run fast). Like this we can just directly put the normal parameters inside the notebooks, and only modify the extracted code when we run the tests, without affecting the .ipynb files. 

In order to run these tests inside the temporary directory created by pytest, we need to retrieve its path (which can only be done a certain way), this is why during the test session we save the path in a file locally in order to be able to use it during tests, and we delete that residual file at the end of the tests session. I can develop the explanation about this if needed.

Closes #234 