### PR TITLE
Minor clarifications on how to load data with scvi

### DIFF
--- a/scvi/dataset/dataset.py
+++ b/scvi/dataset/dataset.py
@@ -240,6 +240,9 @@ class GeneExpressionDataset(Dataset):
         if os.path.exists(os.path.join(save_path, download_name)):
             print("File %s already downloaded" % (os.path.join(save_path, download_name)))
             return
+        if url is None:
+            print("You are trying to load a local file named %s and located at %d but this file was not found"
+                  " at this location" % (download_name, save_path))
         r = urllib.request.urlopen(url)
         print("Downloading file at %s" % os.path.join(save_path, download_name))
 

--- a/scvi/dataset/dataset.py
+++ b/scvi/dataset/dataset.py
@@ -241,8 +241,8 @@ class GeneExpressionDataset(Dataset):
             print("File %s already downloaded" % (os.path.join(save_path, download_name)))
             return
         if url is None:
-            print("You are trying to load a local file named %s and located at %d but this file was not found"
-                  " at this location" % (download_name, save_path))
+            print("You are trying to load a local file named %s and located at %s but this file was not found"
+                  " at the location %s" % (download_name, save_path, os.path.join(save_path, download_name)))
         r = urllib.request.urlopen(url)
         print("Downloading file at %s" % os.path.join(save_path, download_name))
 

--- a/scvi/dataset/dataset10X.py
+++ b/scvi/dataset/dataset10X.py
@@ -78,7 +78,7 @@ class Dataset10X(GeneExpressionDataset):
             self.download_name = self.save_name + '.tar.gz'
         else:
             try:
-                assert os.path.isdir(self.save_path + filename)
+                assert os.path.isdir(os.path.join(self.save_path, filename))
             except AssertionError:
                 print("The file %s was not found in the location you gave" % filename)
                 raise

--- a/tests/notebooks/data_loading.ipynb
+++ b/tests/notebooks/data_loading.ipynb
@@ -58,7 +58,9 @@
     "* `.loom` files\n",
     "* `.csv` files \n",
     "* `.h5ad` files\n",
-    "* datasets from `10x` website "
+    "* datasets from `10x` website \n",
+    "\n",
+    "Most of the dataset loading instances implemented in scvi use a positional argument `filename` and an optional argument `save_path` (value by default: `data/`). Files will be downloaded or searched for at the location `os.path.join(save_path, filename)`, make sure this path is valid when you specify the arguments."
    ]
   },
   {
@@ -66,7 +68,7 @@
    "metadata": {},
    "source": [
     "### Loading a `.loom` file\n",
-    "Any `.loom` file can be loaded with initializing `LoomDataset` with `filename`. \n",
+    "Any `.loom` file can be loaded with initializing `LoomDataset` with `filename`.\n",
     "\n",
     "Optional parameters: \n",
     "* `save_path`: save path (default to be `data/`) of the file\n",
@@ -123,7 +125,7 @@
    "metadata": {},
    "source": [
     "### Loading a `.csv` file \n",
-    "Any `.csv` file can be loaded with initializing `CsvDataset` with `filename`. \n",
+    "Any `.csv` file can be loaded with initializing `CsvDataset` with `filename`.\n",
     "\n",
     "Optional parameters: \n",
     "* `save_path`: save path (default to be `data/`) of the file\n",
@@ -194,7 +196,7 @@
    "metadata": {},
    "source": [
     "### Loading a `.h5ad` file\n",
-    "[AnnData](http://anndata.readthedocs.io/en/latest/) objects can be stored in `.h5ad` format. Any `.h5ad` file can be loaded with initializing `AnnDataset` with `filename`. \n",
+    "[AnnData](http://anndata.readthedocs.io/en/latest/) objects can be stored in `.h5ad` format. Any `.h5ad` file can be loaded with initializing `AnnDataset` with `filename`.\n",
     "\n",
     "Optional parameters: \n",
     "* `save_path`: save path (default to be `data/`) of the file\n",


### PR DESCRIPTION
Several users encounter errors when they try to load data that is stored locally on their machine because they make mistakes when entering the `filename` and `save_path` arguments. 

- Replacing occurences of path1 + path2 with os.path.join(path1, path2) is an improvement.
- Added some recommandations in the notebook
- Added a message to the user when the module can't find the data because the path is broken