### PR TITLE
Not calling plt.show during test sessions to avoid warnings

### DIFF
--- a/scvi/benchmark.py
+++ b/scvi/benchmark.py
@@ -8,7 +8,7 @@ from scvi.inference.posterior import proximity_imputation
 from scvi.models import VAE, VAEF
 
 
-def cortex_benchmark(n_epochs=250, use_cuda=True, save_path='data/'):
+def cortex_benchmark(n_epochs=250, use_cuda=True, save_path='data/', show_plot=True):
     cortex_dataset = CortexDataset(save_path=save_path)
     vae = VAE(cortex_dataset.nb_genes)
     trainer_cortex_vae = UnsupervisedTrainer(vae, cortex_dataset, use_cuda=use_cuda)
@@ -22,7 +22,7 @@ def cortex_benchmark(n_epochs=250, use_cuda=True, save_path='data/'):
     trainer_cortex_vae.corrupt_posteriors()
     trainer_cortex_vae.train(n_epochs=n_epochs)
     trainer_cortex_vae.uncorrupt_posteriors()
-    trainer_cortex_vae.train_set.imputation_benchmark(verbose=(n_epochs > 1), save_path=save_path)
+    trainer_cortex_vae.train_set.imputation_benchmark(verbose=(n_epochs > 1), save_path=save_path, show_plot=show_plot)
 
     n_samples = 10 if n_epochs == 1 else None  # n_epochs == 1 is unit tests
     trainer_cortex_vae.train_set.show_t_sne(n_samples=n_samples)
@@ -48,8 +48,8 @@ def annotation_benchmarks(n_epochs=1, use_cuda=True, save_path='data/'):
     pass
 
 
-def all_benchmarks(n_epochs=250, use_cuda=True, save_path='data/'):
-    cortex_benchmark(n_epochs=n_epochs, use_cuda=use_cuda, save_path=save_path)
+def all_benchmarks(n_epochs=250, use_cuda=True, save_path='data/', show_plot=True):
+    cortex_benchmark(n_epochs=n_epochs, use_cuda=use_cuda, save_path=save_path, show_plot=show_plot)
 
     harmonization_benchmarks(n_epochs=n_epochs, use_cuda=use_cuda, save_path=save_path)
     annotation_benchmarks(n_epochs=n_epochs, use_cuda=use_cuda, save_path=save_path)

--- a/scvi/inference/posterior.py
+++ b/scvi/inference/posterior.py
@@ -360,7 +360,7 @@ class Posterior:
         return np.median(np.abs(np.concatenate(original_list) - np.concatenate(imputed_list)))
 
     @torch.no_grad()
-    def imputation_benchmark(self, n_samples=8, verbose=False, title_plot='imputation', save_path=''):
+    def imputation_benchmark(self, n_samples=8, verbose=False, show_plot=True, title_plot='imputation', save_path=''):
         original_list, imputed_list = self.imputation_list(n_samples=n_samples)
         # Median of medians for all distances
         median_score = self.imputation_score(original_list=original_list, imputed_list=imputed_list)
@@ -375,8 +375,8 @@ class Posterior:
         if verbose:
             print("\nMedian of Median: %.4f\nMean of Median for each cell: %.4f" % (median_score, mean_score))
 
-        plot_imputation(np.concatenate(original_list), np.concatenate(imputed_list), title=os.path.join(save_path,
-                                                                                                        title_plot))
+        plot_imputation(np.concatenate(original_list), np.concatenate(imputed_list), show_plot=show_plot,
+                        title=os.path.join(save_path, title_plot))
         return original_list, imputed_list
 
     @torch.no_grad()
@@ -562,7 +562,7 @@ def get_bayes_factors(px_scale, all_labels, cell_idx, other_cell_idx=None, genes
     return res
 
 
-def plot_imputation(original, imputed, title="Imputation"):
+def plot_imputation(original, imputed, show_plot=True, title="Imputation"):
     y = imputed
     x = original
 
@@ -606,7 +606,8 @@ def plot_imputation(original, imputed, title="Imputation"):
     plt.plot(linspace, a * linspace, color='black')
 
     plt.plot(linspace, linspace, color='black', linestyle=":")
-    plt.show()
+    if show_plot:
+        plt.show()
     plt.savefig(title + '.png')
 
 

--- a/tests/notebooks/annotation.ipynb
+++ b/tests/notebooks/annotation.ipynb
@@ -173,8 +173,7 @@
     "accuracy_unlabelled_set = trainer_scanvi.history[\"accuracy_unlabelled_set\"]\n",
     "x = np.linspace(0,n_epochs,(len(accuracy_labelled_set)))\n",
     "plt.plot(x, accuracy_labelled_set, label=\"accuracy labelled\")\n",
-    "plt.plot(x, accuracy_unlabelled_set, label=\"accuracy unlabelled\")\n",
-    "plt.show()"
+    "plt.plot(x, accuracy_unlabelled_set, label=\"accuracy unlabelled\")"
    ]
   },
   {
@@ -649,7 +648,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.6"
+   "version": "3.7.0"
   }
  },
  "nbformat": 4,

--- a/tests/notebooks/basic_tutorial.ipynb
+++ b/tests/notebooks/basic_tutorial.ipynb
@@ -47,7 +47,8 @@
    ],
    "source": [
     "n_epochs_all = None\n",
-    "save_path = 'data/'"
+    "save_path = 'data/'\n",
+    "show_plot = True"
    ]
   },
   {
@@ -185,8 +186,7 @@
     "x = np.linspace(0,500,(len(ll_train_set)))\n",
     "plt.plot(x, ll_train_set)\n",
     "plt.plot(x, ll_test_set)\n",
-    "plt.ylim(1150,1600)\n",
-    "plt.show()"
+    "plt.ylim(1150,1600)"
    ]
   },
   {
@@ -313,7 +313,8 @@
     "trainer.train(n_epochs)\n",
     "trainer.uncorrupt_posteriors()\n",
     "\n",
-    "original_list, imputed_list = trainer.train_set.imputation_benchmark(verbose=True, n_samples=1, save_path=save_path)"
+    "original_list, imputed_list = trainer.train_set.imputation_benchmark(verbose=True, n_samples=1, \n",
+    "                                                                     show_plot=show_plot, save_path=save_path)"
    ]
   },
   {
@@ -791,8 +792,7 @@
     "x = np.linspace(0,50,(len(ll_train)))\n",
     "plt.plot(x, ll_train)\n",
     "plt.plot(x, ll_test)\n",
-    "plt.ylim(min(ll_train)-50, 3500)\n",
-    "plt.show()"
+    "plt.ylim(min(ll_train)-50, 3500)"
    ]
   },
   {

--- a/tests/notebooks/scRNA_and_smFISH.ipynb
+++ b/tests/notebooks/scRNA_and_smFISH.ipynb
@@ -58,7 +58,8 @@
    ],
    "source": [
     "n_epochs_all = None\n",
-    "save_path = 'data/'"
+    "save_path = 'data/'\n",
+    "show_plot = True"
    ]
   },
   {
@@ -337,7 +338,8 @@
     "imputed = expected_frequencies_fish[:, idx_gad] \n",
     "imputed = imputed / np.sum(expected_frequencies_fish[:, vae.indexes_to_keep], axis=1).ravel()\n",
     "imputed *= np.sum(values_fish[:, vae.indexes_to_keep], axis=1)\n",
-    "plot_imputation(np.log(1+values_fish[:, idx_gad]), np.log(1+imputed), title=os.path.join(save_path, 'imputation'))\n",
+    "plot_imputation(np.log(1+values_fish[:, idx_gad]), np.log(1+imputed), show_plot=show_plot,\n",
+    "                title=os.path.join(save_path, 'imputation'))\n",
     "print(imputation_metrics(values_fish[:, idx_gad], imputed))"
    ]
   },
@@ -377,8 +379,8 @@
     "predicted_PCA = proximity_imputation(PCA_latent_seq, PCA_values_seq[:, idx_gad], PCA_latent_fish, k=5)\n",
     "mean = np.mean(PCA_values_fish[:, idx_gad])\n",
     "to_keep = [idx for idx in range(len(PCA_values_fish[:, idx_gad])) if PCA_values_fish[idx, 0]<mean]\n",
-    "plot_imputation(np.log(1+predicted_PCA), np.log(1+PCA_values_fish[:, idx_gad]), title=os.path.join(save_path, \n",
-    "                                                                                                  'imputation'))\n",
+    "plot_imputation(np.log(1+predicted_PCA), np.log(1+PCA_values_fish[:, idx_gad]), show_plot=show_plot, \n",
+    "                title=os.path.join(save_path, 'imputation'))\n",
     "print(imputation_metrics(PCA_values_fish[:, idx_gad], predicted_PCA))"
    ]
   },
@@ -426,7 +428,8 @@
     "imputed = imputed / np.sum(expected_frequencies_fish[:, vae.indexes_to_keep], axis=1).ravel()\n",
     "imputed *= np.sum(values_fish[:, vae.indexes_to_keep], axis=1)\n",
     "mean = np.mean(values_fish[:, idx_sox])\n",
-    "plot_imputation(np.log(1+imputed), np.log(1+values_fish[:, idx_sox]), title=os.path.join(save_path, 'imputation'))\n",
+    "plot_imputation(np.log(1+imputed), np.log(1+values_fish[:, idx_sox]), show_plot=show_plot, \n",
+    "                title=os.path.join(save_path, 'imputation'))\n",
     "print(imputation_metrics(values_fish[:, idx_sox], imputed))"
    ]
   },
@@ -466,8 +469,8 @@
     "predicted_PCA = proximity_imputation(PCA_latent_seq, PCA_values_seq[:, idx_sox], PCA_latent_fish, k=5)\n",
     "mean = np.mean(PCA_values_fish[:, idx_sox])\n",
     "to_keep = [idx for idx in range(len(PCA_values_fish[:, idx_sox])) if PCA_values_fish[idx, idx_sox]<mean]\n",
-    "plot_imputation(np.log(1+predicted_PCA), np.log(1+PCA_values_fish[:, idx_sox]), title=os.path.join(save_path, \n",
-    "                                                                                                   'imputation'))\n",
+    "plot_imputation(np.log(1+predicted_PCA), np.log(1+PCA_values_fish[:, idx_sox]), show_plot=show_plot, \n",
+    "                title=os.path.join(save_path, 'imputation'))\n",
     "print(imputation_metrics(PCA_values_fish[:, idx_sox], predicted_PCA))"
    ]
   },
@@ -1201,7 +1204,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.6"
+   "version": "3.7.0"
   }
  },
  "nbformat": 4,

--- a/tests/notebooks/scVI_reproducibility.ipynb
+++ b/tests/notebooks/scVI_reproducibility.ipynb
@@ -65,7 +65,8 @@
    ],
    "source": [
     "n_epochs_all = None\n",
-    "save_path = 'data/'"
+    "save_path = 'data/'\n",
+    "show_plot = True"
    ]
   },
   {
@@ -348,7 +349,7 @@
     "trainer_cortex.uncorrupt_posteriors()\n",
     "\n",
     "original_list, imputed_list = trainer_cortex.train_set.imputation_benchmark(n_samples=1, verbose=True, \n",
-    "                                                                            save_path=save_path)"
+    "                                                                            show_plot=show_plot, save_path=save_path)"
    ]
   },
   {
@@ -1001,8 +1002,7 @@
     "cd14_raw_data = cd14_posterior.raw_data()[0].A\n",
     "plt.scatter(libraries, np.log(np.sum(cd14_raw_data, axis=1)), alpha=0.5)\n",
     "plt.xlabel('log scaling factor for each cell')\n",
-    "plt.ylabel('log-library size for each cell')\n",
-    "plt.show()"
+    "plt.ylabel('log-library size for each cell')"
    ]
   },
   {
@@ -1065,9 +1065,7 @@
     "plt.xlabel('Average frequency per cell')\n",
     "plt.ylabel('Average number of zeros')\n",
     "\n",
-    "plt.scatter(m, p, alpha=0.5, color=\"grey\", marker=\"x\")\n",
-    "\n",
-    "plt.show()"
+    "plt.scatter(m, p, alpha=0.5, color=\"grey\", marker=\"x\")"
    ]
   },
   {
@@ -1422,8 +1420,6 @@
     "    ax.set_xlabel(title)\n",
     "    ax.set_yticks(ind)\n",
     "    ax.set_yticklabels(alg)\n",
-    "    \n",
-    "    plt.show()\n",
     "\n",
     "def barplot_CITE_list(mean, alg, title, save=None, interest=0, figsize=None):\n",
     "    \n",
@@ -1897,7 +1893,8 @@
     "trainer_cortex.train(n_epochs=n_epochs)\n",
     "trainer_cortex.uncorrupt_posteriors()\n",
     "\n",
-    "original_list, imputed_list = trainer_cortex.train_set.imputation_benchmark(n_samples=1, save_path=save_path)"
+    "original_list, imputed_list = trainer_cortex.train_set.imputation_benchmark(n_samples=1, show_plot=show_plot, \n",
+    "                                                                            save_path=save_path)"
    ]
   },
   {
@@ -2404,8 +2401,7 @@
     "# add some text for labels, title and axes ticks\n",
     "ax.set_ylabel('Imputation score for 120 epochs')\n",
     "ax.set_xticks(list(results.keys()))\n",
-    "ax.set_xlabel(\"Dimension of latent variables\")\n",
-    "plt.show()"
+    "ax.set_xlabel(\"Dimension of latent variables\")"
    ]
   },
   {
@@ -2460,8 +2456,7 @@
     "plt.plot(trainer_brain_large.history[\"ll_test_set\"][2:],  marker='o', linestyle='--',label=\"Validation\", alpha=0.5)\n",
     "plt.legend()\n",
     "plt.ylabel(\"negative log-likelihood on a minibatch\")\n",
-    "plt.xlabel(\"epochs\")\n",
-    "plt.show()"
+    "plt.xlabel(\"epochs\")"
    ]
   },
   {
@@ -2487,8 +2482,7 @@
     "\n",
     "plt.plot(history_impute,  marker='+', linestyle=\"--\", alpha=0.5)\n",
     "plt.ylabel(\"Imputation error\")\n",
-    "plt.xlabel(\"epochs\")\n",
-    "plt.show()"
+    "plt.xlabel(\"epochs\")"
    ]
   },
   {
@@ -2558,9 +2552,7 @@
     "ax.set_xlabel(\"Dimension of latent variables\")\n",
     "plt.legend()\n",
     "\n",
-    "plt.savefig(os.path.join(save_path, \"zeiler_clustering_dimension_stability.pdf\"), dpi=300)\n",
-    "\n",
-    "plt.show()"
+    "plt.savefig(os.path.join(save_path, \"zeiler_clustering_dimension_stability.pdf\"), dpi=300)"
    ]
   },
   {
@@ -2782,7 +2774,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.6"
+   "version": "3.7.0"
   }
  },
  "nbformat": 4,

--- a/tests/test_notebook.py
+++ b/tests/test_notebook.py
@@ -77,6 +77,7 @@ class NotebookLoader(object):
                         code = re.sub(r'n_samples_tsne = \d+', "n_samples_tsne = 10", code)
                         code = re.sub(r'n_samples_posterior_density = \d+', "n_samples_posterior_density = 2", code)
                         code = re.sub("save_path = 'data/'", "save_path = '"+os.getcwd()+"'", code)
+                        code = re.sub("show_plot = True", "show_plot = False", code)
                         # run the code in themodule
                         exec(code, mod.__dict__)
                         plt.close('all')

--- a/tests/test_scvi.py
+++ b/tests/test_scvi.py
@@ -34,7 +34,8 @@ def test_cortex(save_path):
     trainer_cortex_vae.train(n_epochs=1)
     trainer_cortex_vae.uncorrupt_posteriors()
 
-    trainer_cortex_vae.train_set.imputation_benchmark(n_samples=1, title_plot='imputation', save_path=save_path)
+    trainer_cortex_vae.train_set.imputation_benchmark(n_samples=1, show_plot=False,
+                                                      title_plot='imputation', save_path=save_path)
 
     svaec = SCANVI(cortex_dataset.nb_genes, cortex_dataset.n_batches, cortex_dataset.n_labels)
     trainer_cortex_svaec = JointSemiSupervisedTrainer(svaec, cortex_dataset,
@@ -108,7 +109,7 @@ def base_benchmark(gene_dataset):
 
 
 def test_all_benchmarks(save_path):
-    all_benchmarks(n_epochs=1, save_path=save_path)
+    all_benchmarks(n_epochs=1, save_path=save_path, show_plot=False)
 
 
 def test_synthetic_3():


### PR DESCRIPTION
With `matplotlib == 3.0.1`, calling `plt.show()` raises warnings during test sessions.

- I suppressed the direct calls to `plt.show()` in all notebooks, the presence of the magic command `%matplotlib inline` is sufficient to show plots in the notebooks, however this line is not executed during tests because it raises errors and is not necessary
- I added a boolean argument `show_plot` to methods like `imputation_benchmark` and `plot_imputation` that call plt.show which is needed when running this code outside of notebooks, this argument is set to `False` during tests so only the line `plt.show()` is skipped in these methods during tests

PS: don't mind the name of the commit, this is a typing error, this PR is unrelated to the issue 237

Closes #239 