### PR TITLE
autoreload compatibility

### DIFF
--- a/scvi/dataset/anndata.py
+++ b/scvi/dataset/anndata.py
@@ -38,7 +38,7 @@ class AnnDataset(GeneExpressionDataset):
         data, gene_names = self.download_and_preprocess()
 
         super().__init__(*GeneExpressionDataset.get_attributes_from_matrix(data),
-                                         gene_names=gene_names)
+                         gene_names=gene_names)
 
         self.subsample_genes(new_n_genes=new_n_genes, subset_genes=subset_genes)
 

--- a/scvi/dataset/anndata.py
+++ b/scvi/dataset/anndata.py
@@ -37,7 +37,7 @@ class AnnDataset(GeneExpressionDataset):
 
         data, gene_names = self.download_and_preprocess()
 
-        super(AnnDataset, self).__init__(*GeneExpressionDataset.get_attributes_from_matrix(data),
+        super().__init__(*GeneExpressionDataset.get_attributes_from_matrix(data),
                                          gene_names=gene_names)
 
         self.subsample_genes(new_n_genes=new_n_genes, subset_genes=subset_genes)

--- a/scvi/dataset/brain_large.py
+++ b/scvi/dataset/brain_large.py
@@ -43,7 +43,7 @@ class BrainLargeDataset(GeneExpressionDataset):
         self.download_name = "genomics.h5"
 
         Xs = self.download_and_preprocess()
-        super(BrainLargeDataset, self).__init__(
+        super().__init__(
             *GeneExpressionDataset.get_attributes_from_list(Xs)
         )
 

--- a/scvi/dataset/cite_seq.py
+++ b/scvi/dataset/cite_seq.py
@@ -37,7 +37,7 @@ class CiteSeqDataset(GeneExpressionDataset):
 
         expression_data = self.download_and_preprocess()
 
-        super(CiteSeqDataset, self).__init__(
+        super().__init__(
             *GeneExpressionDataset.get_attributes_from_matrix(expression_data)
         )
 
@@ -85,4 +85,4 @@ class CbmcDataset(CiteSeqDataset):
 
     """
     def __init__(self, save_path='data/citeSeq/'):
-        super(CbmcDataset, self).__init__(name="cbmc", save_path=save_path)
+        super().__init__(name="cbmc", save_path=save_path)

--- a/scvi/dataset/cite_seq.py
+++ b/scvi/dataset/cite_seq.py
@@ -84,5 +84,6 @@ class CbmcDataset(CiteSeqDataset):
         >>> gene_dataset = CbmcDataset()
 
     """
+
     def __init__(self, save_path='data/citeSeq/'):
         super().__init__(name="cbmc", save_path=save_path)

--- a/scvi/dataset/cortex.py
+++ b/scvi/dataset/cortex.py
@@ -38,7 +38,7 @@ class CortexDataset(GeneExpressionDataset):
         self.additional_genes = additional_genes
         expression_data, labels, gene_names, cell_types = self.download_and_preprocess()
 
-        super(CortexDataset, self).__init__(
+        super().__init__(
             *GeneExpressionDataset.get_attributes_from_matrix(
                 expression_data,
                 labels=labels),

--- a/scvi/dataset/csv.py
+++ b/scvi/dataset/csv.py
@@ -41,7 +41,7 @@ class CsvDataset(GeneExpressionDataset):
 
         data, gene_names, labels, cell_types = self.download_and_preprocess()
 
-        super(CsvDataset, self).__init__(
+        super().__init__(
             *GeneExpressionDataset.get_attributes_from_matrix(
                 data, labels=labels), gene_names=gene_names, cell_types=cell_types)
 
@@ -71,7 +71,7 @@ class CsvDataset(GeneExpressionDataset):
 
 class BreastCancerDataset(CsvDataset):
     def __init__(self, save_path='data/'):
-        super(BreastCancerDataset, self).__init__("Layer2_BC_count_matrix-1.tsv", save_path=save_path,
+        super().__init__("Layer2_BC_count_matrix-1.tsv", save_path=save_path,
                                                   url="http://www.spatialtranscriptomicsresearch.org/wp-content/"
                                                       "uploads/2016/07/Layer2_BC_count_matrix-1.tsv",
                                                   sep='\t', gene_by_cell=False)
@@ -79,7 +79,7 @@ class BreastCancerDataset(CsvDataset):
 
 class MouseOBDataset(CsvDataset):
     def __init__(self, save_path='data/'):
-        super(MouseOBDataset, self).__init__("Rep11_MOB_count_matrix-1.tsv", save_path=save_path,
+        super().__init__("Rep11_MOB_count_matrix-1.tsv", save_path=save_path,
                                              url="http://www.spatialtranscriptomicsresearch.org/wp-content/uploads/"
                                                  "2016/07/Rep11_MOB_count_matrix-1.tsv",
                                              sep='\t', gene_by_cell=False)

--- a/scvi/dataset/csv.py
+++ b/scvi/dataset/csv.py
@@ -29,6 +29,7 @@ class CsvDataset(GeneExpressionDataset):
         ... save_path='data/', compression='gzip')
 
     """
+
     def __init__(self, filename, save_path='data/', url=None, new_n_genes=600, subset_genes=None,
                  compression=None, sep=',', gene_by_cell=True, labels_file=None):
         self.download_name = filename  # The given csv file is
@@ -72,14 +73,14 @@ class CsvDataset(GeneExpressionDataset):
 class BreastCancerDataset(CsvDataset):
     def __init__(self, save_path='data/'):
         super().__init__("Layer2_BC_count_matrix-1.tsv", save_path=save_path,
-                                                  url="http://www.spatialtranscriptomicsresearch.org/wp-content/"
-                                                      "uploads/2016/07/Layer2_BC_count_matrix-1.tsv",
-                                                  sep='\t', gene_by_cell=False)
+                         url="http://www.spatialtranscriptomicsresearch.org/wp-content/"
+                             "uploads/2016/07/Layer2_BC_count_matrix-1.tsv",
+                         sep='\t', gene_by_cell=False)
 
 
 class MouseOBDataset(CsvDataset):
     def __init__(self, save_path='data/'):
         super().__init__("Rep11_MOB_count_matrix-1.tsv", save_path=save_path,
-                                             url="http://www.spatialtranscriptomicsresearch.org/wp-content/uploads/"
-                                                 "2016/07/Rep11_MOB_count_matrix-1.tsv",
-                                             sep='\t', gene_by_cell=False)
+                         url="http://www.spatialtranscriptomicsresearch.org/wp-content/uploads/"
+                             "2016/07/Rep11_MOB_count_matrix-1.tsv",
+                         sep='\t', gene_by_cell=False)

--- a/scvi/dataset/dataset10X.py
+++ b/scvi/dataset/dataset10X.py
@@ -87,7 +87,7 @@ class Dataset10X(GeneExpressionDataset):
         self.dense = dense
 
         expression_data, gene_names = self.download_and_preprocess()
-        super(Dataset10X, self).__init__(*GeneExpressionDataset.get_attributes_from_matrix(
+        super().__init__(*GeneExpressionDataset.get_attributes_from_matrix(
             expression_data), gene_names=gene_names)
 
     def preprocess(self):
@@ -151,5 +151,5 @@ class BrainSmallDataset(Dataset10X):
         self.raw_qc = metadata['raw_qc'].loc[dataset.barcodes.values.ravel()]
         self.qc_names = self.raw_qc.columns
         self.qc = self.raw_qc.values
-        super(Dataset10X, self).__init__(dataset.X, dataset.local_means, dataset.local_vars,
+        super().__init__(dataset.X, dataset.local_means, dataset.local_vars,
                                          batch_indices=dataset.batch_indices, labels=labels)

--- a/scvi/dataset/dataset10X.py
+++ b/scvi/dataset/dataset10X.py
@@ -151,5 +151,5 @@ class BrainSmallDataset(Dataset10X):
         self.raw_qc = metadata['raw_qc'].loc[dataset.barcodes.values.ravel()]
         self.qc_names = self.raw_qc.columns
         self.qc = self.raw_qc.values
-        Dataset10X.__init__(self, dataset.X, dataset.local_means, dataset.local_vars,
-                            batch_indices=dataset.batch_indices, labels=labels)
+        GeneExpressionDataset.__init__(self, dataset.X, dataset.local_means, dataset.local_vars,
+                                       batch_indices=dataset.batch_indices, labels=labels)

--- a/scvi/dataset/dataset10X.py
+++ b/scvi/dataset/dataset10X.py
@@ -151,5 +151,5 @@ class BrainSmallDataset(Dataset10X):
         self.raw_qc = metadata['raw_qc'].loc[dataset.barcodes.values.ravel()]
         self.qc_names = self.raw_qc.columns
         self.qc = self.raw_qc.values
-        super().__init__(dataset.X, dataset.local_means, dataset.local_vars,
-                         batch_indices=dataset.batch_indices, labels=labels)
+        Dataset10X.__init__(self, dataset.X, dataset.local_means, dataset.local_vars,
+                            batch_indices=dataset.batch_indices, labels=labels)

--- a/scvi/dataset/dataset10X.py
+++ b/scvi/dataset/dataset10X.py
@@ -152,4 +152,4 @@ class BrainSmallDataset(Dataset10X):
         self.qc_names = self.raw_qc.columns
         self.qc = self.raw_qc.values
         super().__init__(dataset.X, dataset.local_means, dataset.local_vars,
-                                         batch_indices=dataset.batch_indices, labels=labels)
+                         batch_indices=dataset.batch_indices, labels=labels)

--- a/scvi/dataset/hemato.py
+++ b/scvi/dataset/hemato.py
@@ -38,7 +38,7 @@ class HematoDataset(GeneExpressionDataset):
 
         expression_data, gene_names, labels, self.y_spring, self.y_spring = self.download_and_preprocess()
 
-        super(HematoDataset, self).__init__(
+        super().__init__(
             *GeneExpressionDataset.get_attributes_from_matrix(
                 expression_data, labels=labels), gene_names=gene_names,
 

--- a/scvi/dataset/loom.py
+++ b/scvi/dataset/loom.py
@@ -34,7 +34,7 @@ class LoomDataset(GeneExpressionDataset):
             GeneExpressionDataset.get_attributes_from_matrix(data, labels=labels)
         batch_indices = batch_indices if batch_indices is not None else batch_indices_
         super().__init__(X, local_means, local_vars, batch_indices, labels,
-                                          gene_names=gene_names, cell_types=cell_types)
+                         gene_names=gene_names, cell_types=cell_types)
 
     def preprocess(self):
         print("Preprocessing dataset")
@@ -79,7 +79,7 @@ class RetinaDataset(LoomDataset):
     """
     def __init__(self, save_path='data/'):
         super().__init__(filename='retina.loom',
-                                            save_path=save_path,
-                                            url='https://github.com/YosefLab/scVI-data/raw/master/retina.loom')
+                         save_path=save_path,
+                         url='https://github.com/YosefLab/scVI-data/raw/master/retina.loom')
         self.cell_types = ["RBC", "MG", "BC5A", "BC7", "BC6", "BC5C", "BC1A", "BC3B", "BC1B", "BC2", "BC5D", "BC3A",
                            "BC5B", "BC4", "BC8_9"]

--- a/scvi/dataset/loom.py
+++ b/scvi/dataset/loom.py
@@ -33,7 +33,7 @@ class LoomDataset(GeneExpressionDataset):
         X, local_means, local_vars, batch_indices_, labels = \
             GeneExpressionDataset.get_attributes_from_matrix(data, labels=labels)
         batch_indices = batch_indices if batch_indices is not None else batch_indices_
-        super(LoomDataset, self).__init__(X, local_means, local_vars, batch_indices, labels,
+        super().__init__(X, local_means, local_vars, batch_indices, labels,
                                           gene_names=gene_names, cell_types=cell_types)
 
     def preprocess(self):
@@ -78,7 +78,7 @@ class RetinaDataset(LoomDataset):
 
     """
     def __init__(self, save_path='data/'):
-        super(RetinaDataset, self).__init__(filename='retina.loom',
+        super().__init__(filename='retina.loom',
                                             save_path=save_path,
                                             url='https://github.com/YosefLab/scVI-data/raw/master/retina.loom')
         self.cell_types = ["RBC", "MG", "BC5A", "BC7", "BC6", "BC5C", "BC1A", "BC3B", "BC1B", "BC2", "BC5D", "BC3A",

--- a/scvi/dataset/pbmc.py
+++ b/scvi/dataset/pbmc.py
@@ -42,7 +42,7 @@ class PbmcDataset(GeneExpressionDataset):
         )
         self.barcodes = pd.concat(pbmc.barcodes).values.ravel().astype(str)
         super().__init__(pbmc.X, pbmc.local_means, pbmc.local_vars,
-                                          pbmc.batch_indices, pbmc.labels, pbmc.gene_names)
+                         pbmc.batch_indices, pbmc.labels, pbmc.gene_names)
 
         dict_barcodes = dict(zip(self.barcodes, np.arange(len(self.barcodes))))
         subset_cells = []
@@ -98,5 +98,5 @@ class PurifiedPBMCDataset(GeneExpressionDataset):
         pbmc = GeneExpressionDataset.concat_datasets(*datasets, shared_batches=True)
         pbmc.subsample_genes(subset_genes=(np.array(pbmc.X.sum(axis=0)) > 0).ravel())
         super().__init__(pbmc.X, pbmc.local_means, pbmc.local_vars,
-                                                  pbmc.batch_indices, pbmc.labels,
-                                                  gene_names=pbmc.gene_names, cell_types=pbmc.cell_types)
+                         pbmc.batch_indices, pbmc.labels,
+                         gene_names=pbmc.gene_names, cell_types=pbmc.cell_types)

--- a/scvi/dataset/pbmc.py
+++ b/scvi/dataset/pbmc.py
@@ -41,7 +41,7 @@ class PbmcDataset(GeneExpressionDataset):
             Dataset10X("pbmc4k", save_path=save_path)
         )
         self.barcodes = pd.concat(pbmc.barcodes).values.ravel().astype(str)
-        super(PbmcDataset, self).__init__(pbmc.X, pbmc.local_means, pbmc.local_vars,
+        super().__init__(pbmc.X, pbmc.local_means, pbmc.local_vars,
                                           pbmc.batch_indices, pbmc.labels, pbmc.gene_names)
 
         dict_barcodes = dict(zip(self.barcodes, np.arange(len(self.barcodes))))
@@ -97,6 +97,6 @@ class PurifiedPBMCDataset(GeneExpressionDataset):
 
         pbmc = GeneExpressionDataset.concat_datasets(*datasets, shared_batches=True)
         pbmc.subsample_genes(subset_genes=(np.array(pbmc.X.sum(axis=0)) > 0).ravel())
-        super(PurifiedPBMCDataset, self).__init__(pbmc.X, pbmc.local_means, pbmc.local_vars,
+        super().__init__(pbmc.X, pbmc.local_means, pbmc.local_vars,
                                                   pbmc.batch_indices, pbmc.labels,
                                                   gene_names=pbmc.gene_names, cell_types=pbmc.cell_types)

--- a/scvi/dataset/seqfish.py
+++ b/scvi/dataset/seqfish.py
@@ -12,7 +12,7 @@ class SeqfishDataset(GeneExpressionDataset):
 
         data = self.download_and_preprocess()
 
-        super(SeqfishDataset, self).__init__(*GeneExpressionDataset.get_attributes_from_matrix(data))
+        super().__init__(*GeneExpressionDataset.get_attributes_from_matrix(data))
 
     def preprocess(self):
         print("Preprocessing dataset")

--- a/scvi/dataset/smfish.py
+++ b/scvi/dataset/smfish.py
@@ -12,7 +12,7 @@ class SmfishDataset(GeneExpressionDataset):
         self.url = 'http://linnarssonlab.org/osmFISH/osmFISH_SScortex_mouse_all_cells.loom'
         self.cell_type_level = cell_type_level
         data, labels, gene_names, cell_types, x_coord, y_coord = self.download_and_preprocess()
-        super(SmfishDataset, self).__init__(
+        super().__init__(
             *GeneExpressionDataset.get_attributes_from_matrix(
                 data,
                 labels=labels), gene_names=gene_names,

--- a/scvi/dataset/synthetic.py
+++ b/scvi/dataset/synthetic.py
@@ -12,7 +12,7 @@ class SyntheticDataset(GeneExpressionDataset):
         mask = np.random.binomial(n=1, p=0.7, size=(n_batches, batch_size, nb_genes))
         newdata = (data * mask)  # We put the batch index first
         labels = np.random.randint(0, n_labels, size=(n_batches, batch_size, 1))
-        super(SyntheticDataset, self).__init__(
+        super().__init__(
             *GeneExpressionDataset.get_attributes_from_list(newdata, list_labels=labels),
             gene_names=np.arange(nb_genes).astype(np.str)
         )
@@ -39,6 +39,6 @@ class SyntheticRandomDataset(GeneExpressionDataset):  # The exact random paramet
         self.simlr_metadata = pickle.load(open(os.path.join(self.save_path, 'random_metadata.pickle'), 'rb'))
         labels_simlr = self.simlr_metadata['clusters']
 
-        super(SyntheticRandomDataset, self).__init__(
+        super().__init__(
             *GeneExpressionDataset.get_attributes_from_matrix(X_train, labels=labels_simlr)
         )

--- a/scvi/inference/annotation.py
+++ b/scvi/inference/annotation.py
@@ -93,7 +93,7 @@ class ClassifierTrainer(Trainer):
 
     def __init__(self, *args, sampling_model=None, use_cuda=True, **kwargs):
         self.sampling_model = sampling_model
-        super(ClassifierTrainer, self).__init__(*args, use_cuda=use_cuda, **kwargs)
+        super().__init__(*args, use_cuda=use_cuda, **kwargs)
         self.train_set, self.test_set = self.train_test(self.model, self.gene_dataset, type_class=AnnotationPosterior)
 
     @property
@@ -142,7 +142,7 @@ class SemiSupervisedTrainer(UnsupervisedTrainer):
         """
         :param n_labelled_samples_per_class: number of labelled samples per class
         """
-        super(SemiSupervisedTrainer, self).__init__(model, gene_dataset, **kwargs)
+        super().__init__(model, gene_dataset, **kwargs)
         self.model = model
         self.gene_dataset = gene_dataset
 
@@ -195,7 +195,7 @@ class SemiSupervisedTrainer(UnsupervisedTrainer):
         self.classifier_trainer.train_set = labelled_set
 
     def loss(self, tensors_all, tensors_labelled):
-        loss = super(SemiSupervisedTrainer, self).loss(tensors_all)
+        loss = super().loss(tensors_all)
         sample_batch, _, _, _, y = tensors_labelled
         classification_loss = F.cross_entropy(self.model.classify(sample_batch), y.view(-1))
         loss += classification_loss * self.classification_ratio
@@ -205,25 +205,25 @@ class SemiSupervisedTrainer(UnsupervisedTrainer):
         self.model.eval()
         self.classifier_trainer.train(self.n_epochs_classifier, lr=self.lr_classification)
         self.model.train()
-        return super(SemiSupervisedTrainer, self).on_epoch_end()
+        return super().on_epoch_end()
 
     def create_posterior(self, model=None, gene_dataset=None, shuffle=False, indices=None,
                          type_class=AnnotationPosterior):
-        return super(SemiSupervisedTrainer, self).create_posterior(model, gene_dataset, shuffle, indices, type_class)
+        return super().create_posterior(model, gene_dataset, shuffle, indices, type_class)
 
 
 class JointSemiSupervisedTrainer(SemiSupervisedTrainer):
     def __init__(self, model, gene_dataset, **kwargs):
         kwargs.update({'n_epochs_classifier': 0})
-        super(JointSemiSupervisedTrainer, self).__init__(model, gene_dataset, **kwargs)
+        super().__init__(model, gene_dataset, **kwargs)
 
 
 class AlternateSemiSupervisedTrainer(SemiSupervisedTrainer):
     def __init__(self, *args, **kwargs):
-        super(AlternateSemiSupervisedTrainer, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
 
     def loss(self, all_tensor):
-        return super(SemiSupervisedTrainer, self).loss(all_tensor)
+        return UnsupervisedTrainer.loss(self, all_tensor)
 
     @property
     def posteriors_loop(self):

--- a/scvi/inference/fish.py
+++ b/scvi/inference/fish.py
@@ -50,7 +50,7 @@ class TrainerFish(Trainer):
     def __init__(self, model, gene_dataset_seq, gene_dataset_fish, train_size=0.8, test_size=None,
                  use_cuda=True, cl_ratio=0, n_epochs_even=1, n_epochs_kl=2000, n_epochs_cl=1, seed=0, warm_up=10,
                  scale=50, **kwargs):
-        super(TrainerFish, self).__init__(model, gene_dataset_seq, use_cuda=use_cuda, **kwargs)
+        super().__init__(model, gene_dataset_seq, use_cuda=use_cuda, **kwargs)
         self.kl = None
         self.cl_ratio = cl_ratio
         self.n_epochs_cl = n_epochs_cl
@@ -74,7 +74,7 @@ class TrainerFish(Trainer):
             self.adversarial_cls.cuda()
         self.optimizer_cls = torch.optim.Adam(filter(lambda p: p.requires_grad, self.adversarial_cls.parameters()),
                                               lr=lr, weight_decay=weight_decay)
-        super(TrainerFish, self).train(n_epochs=n_epochs, lr=1e-3, params=None)
+        super().train(n_epochs=n_epochs, lr=1e-3, params=None)
 
     @property
     def posteriors_loop(self):

--- a/scvi/inference/inference.py
+++ b/scvi/inference/inference.py
@@ -29,7 +29,7 @@ class UnsupervisedTrainer(Trainer):
     default_metrics_to_monitor = ['ll']
 
     def __init__(self, model, gene_dataset, train_size=0.8, test_size=None, kl=None, **kwargs):
-        super(UnsupervisedTrainer, self).__init__(model, gene_dataset, **kwargs)
+        super().__init__(model, gene_dataset, **kwargs)
         self.kl = kl
         if type(self) is UnsupervisedTrainer:
             self.train_set, self.test_set = self.train_test(model, gene_dataset, train_size, test_size)
@@ -52,7 +52,7 @@ class UnsupervisedTrainer(Trainer):
 
 class AdapterTrainer(UnsupervisedTrainer):
     def __init__(self, model, gene_dataset, posterior_test, frequency=5):
-        super(AdapterTrainer, self).__init__(model, gene_dataset, frequency=frequency)
+        super().__init__(model, gene_dataset, frequency=frequency)
         self.test_set = posterior_test
         self.test_set.to_monitor = ['ll']
         self.params = list(self.model.z_encoder.parameters()) + list(self.model.l_encoder.parameters())
@@ -68,6 +68,6 @@ class AdapterTrainer(UnsupervisedTrainer):
             # Re-initialize to create new path
             self.model.z_encoder.load_state_dict(self.z_encoder_state)
             self.model.l_encoder.load_state_dict(self.l_encoder_state)
-            super(AdapterTrainer, self).train(n_epochs, params=self.params, **kwargs)
+            super().train(n_epochs, params=self.params, **kwargs)
 
         return min(self.history["ll_test_set"])

--- a/scvi/models/classifier.py
+++ b/scvi/models/classifier.py
@@ -5,7 +5,7 @@ from scvi.models.modules import FCLayers
 
 class Classifier(nn.Module):
     def __init__(self, n_input, n_hidden=128, n_labels=10, n_layers=1, dropout_rate=0.1):
-        super(Classifier, self).__init__()
+        super().__init__()
         self.classifier = nn.Sequential(
             FCLayers(n_in=n_input, n_out=n_hidden, n_layers=n_layers,
                      n_hidden=n_hidden, dropout_rate=dropout_rate, use_batch_norm=True),

--- a/scvi/models/modules.py
+++ b/scvi/models/modules.py
@@ -23,7 +23,7 @@ class FCLayers(nn.Module):
 
     def __init__(self, n_in: int, n_out: int, n_cat_list: Iterable[int] = None,
                  n_layers: int = 1, n_hidden: int = 128, dropout_rate: float = 0.1, use_batch_norm=True):
-        super(FCLayers, self).__init__()
+        super().__init__()
         layers_dim = [n_in] + (n_layers - 1) * [n_hidden] + [n_out]
 
         if n_cat_list is not None:
@@ -94,7 +94,7 @@ class Encoder(nn.Module):
     def __init__(self, n_input: int, n_output: int,
                  n_cat_list: Iterable[int] = None, n_layers: int = 1,
                  n_hidden: int = 128, dropout_rate: float = 0.1):
-        super(Encoder, self).__init__()
+        super().__init__()
 
         self.encoder = FCLayers(n_in=n_input, n_out=n_hidden, n_cat_list=n_cat_list, n_layers=n_layers,
                                 n_hidden=n_hidden, dropout_rate=dropout_rate)
@@ -143,7 +143,7 @@ class DecoderSCVI(nn.Module):
     def __init__(self, n_input: int, n_output: int,
                  n_cat_list: Iterable[int] = None, n_layers: int = 1,
                  n_hidden: int = 128):
-        super(DecoderSCVI, self).__init__()
+        super().__init__()
         self.px_decoder = FCLayers(n_in=n_input, n_out=n_hidden,
                                    n_cat_list=n_cat_list, n_layers=n_layers,
                                    n_hidden=n_hidden, dropout_rate=0)
@@ -207,7 +207,7 @@ class Decoder(nn.Module):
 
     def __init__(self, n_input: int, n_output: int, n_cat_list: Iterable[int] = None, n_layers: int = 1,
                  n_hidden: int = 128):
-        super(Decoder, self).__init__()
+        super().__init__()
         self.decoder = FCLayers(n_in=n_input, n_out=n_hidden,
                                 n_cat_list=n_cat_list, n_layers=n_layers,
                                 n_hidden=n_hidden, dropout_rate=0)

--- a/scvi/models/scanvi.py
+++ b/scvi/models/scanvi.py
@@ -55,7 +55,7 @@ class SCANVI(VAE):
                  log_variational: bool = True, reconstruction_loss: str = "zinb",
                  y_prior=None, labels_groups: Sequence[int] = None, use_labels_groups: bool = False,
                  classifier_parameters: dict = dict()):
-        super(SCANVI, self).__init__(n_input, n_hidden=n_hidden, n_latent=n_latent, n_layers=n_layers,
+        super().__init__(n_input, n_hidden=n_hidden, n_latent=n_latent, n_layers=n_layers,
                                      dropout_rate=dropout_rate, n_batch=n_batch, dispersion=dispersion,
                                      log_variational=log_variational, reconstruction_loss=reconstruction_loss)
 
@@ -104,7 +104,7 @@ class SCANVI(VAE):
         return w_y
 
     def get_latents(self, x, y=None):
-        zs = super(SCANVI, self).get_latents(x)
+        zs = super().get_latents(x)
         qz2_m, qz2_v, z2 = self.encoder_z2_z1(zs[0], y)
         if not self.training:
             z2 = qz2_m

--- a/scvi/models/scanvi.py
+++ b/scvi/models/scanvi.py
@@ -56,8 +56,8 @@ class SCANVI(VAE):
                  y_prior=None, labels_groups: Sequence[int] = None, use_labels_groups: bool = False,
                  classifier_parameters: dict = dict()):
         super().__init__(n_input, n_hidden=n_hidden, n_latent=n_latent, n_layers=n_layers,
-                                     dropout_rate=dropout_rate, n_batch=n_batch, dispersion=dispersion,
-                                     log_variational=log_variational, reconstruction_loss=reconstruction_loss)
+                         dropout_rate=dropout_rate, n_batch=n_batch, dispersion=dispersion,
+                         log_variational=log_variational, reconstruction_loss=reconstruction_loss)
 
         self.n_labels = n_labels
         self.n_latent_layers = 2

--- a/scvi/models/vae.py
+++ b/scvi/models/vae.py
@@ -48,7 +48,7 @@ class VAE(nn.Module):
                  n_hidden: int = 128, n_latent: int = 10, n_layers: int = 1,
                  dropout_rate: float = 0.1, dispersion: str = "gene",
                  log_variational: bool = True, reconstruction_loss: str = "zinb"):
-        super(VAE, self).__init__()
+        super().__init__()
         self.dispersion = dispersion
         self.n_latent = n_latent
         self.log_variational = log_variational

--- a/scvi/models/vae_fish.py
+++ b/scvi/models/vae_fish.py
@@ -45,8 +45,8 @@ class VAEF(VAE):
                  dispersion="gene", log_variational=True, reconstruction_loss="zinb",
                  reconstruction_loss_fish="poisson", model_library=False):
         super().__init__(n_input, dispersion=dispersion, n_latent=n_hidden, n_hidden=n_hidden,
-                                   log_variational=log_variational, dropout_rate=dropout_rate, n_layers=1,
-                                   reconstruction_loss=reconstruction_loss, n_batch=n_batch, n_labels=n_labels)
+                         log_variational=log_variational, dropout_rate=dropout_rate, n_layers=1,
+                         reconstruction_loss=reconstruction_loss, n_batch=n_batch, n_labels=n_labels)
         self.n_input = n_input
         self.n_input_fish = len(indexes_fish_train)
         self.indexes_to_keep = indexes_fish_train

--- a/scvi/models/vae_fish.py
+++ b/scvi/models/vae_fish.py
@@ -44,7 +44,7 @@ class VAEF(VAE):
                  n_layers=1, n_layers_decoder=1, dropout_rate=0.3,
                  dispersion="gene", log_variational=True, reconstruction_loss="zinb",
                  reconstruction_loss_fish="poisson", model_library=False):
-        super(VAEF, self).__init__(n_input, dispersion=dispersion, n_latent=n_hidden, n_hidden=n_hidden,
+        super().__init__(n_input, dispersion=dispersion, n_latent=n_hidden, n_hidden=n_hidden,
                                    log_variational=log_variational, dropout_rate=dropout_rate, n_layers=1,
                                    reconstruction_loss=reconstruction_loss, n_batch=n_batch, n_labels=n_labels)
         self.n_input = n_input

--- a/scvi/models/vaec.py
+++ b/scvi/models/vaec.py
@@ -45,7 +45,7 @@ class VAEC(VAE):
 
     def __init__(self, n_input, n_batch, n_labels, n_hidden=128, n_latent=10, n_layers=1, dropout_rate=0.1,
                  y_prior=None, dispersion="gene", log_variational=True, reconstruction_loss="zinb"):
-        super(VAEC, self).__init__(n_input, n_batch, n_labels, n_hidden=n_hidden, n_latent=n_latent, n_layers=n_layers,
+        super().__init__(n_input, n_batch, n_labels, n_hidden=n_hidden, n_latent=n_latent, n_layers=n_layers,
                                    dropout_rate=dropout_rate, dispersion=dispersion, log_variational=log_variational,
                                    reconstruction_loss=reconstruction_loss)
 

--- a/scvi/models/vaec.py
+++ b/scvi/models/vaec.py
@@ -46,8 +46,8 @@ class VAEC(VAE):
     def __init__(self, n_input, n_batch, n_labels, n_hidden=128, n_latent=10, n_layers=1, dropout_rate=0.1,
                  y_prior=None, dispersion="gene", log_variational=True, reconstruction_loss="zinb"):
         super().__init__(n_input, n_batch, n_labels, n_hidden=n_hidden, n_latent=n_latent, n_layers=n_layers,
-                                   dropout_rate=dropout_rate, dispersion=dispersion, log_variational=log_variational,
-                                   reconstruction_loss=reconstruction_loss)
+                         dropout_rate=dropout_rate, dispersion=dispersion, log_variational=log_variational,
+                         reconstruction_loss=reconstruction_loss)
 
         self.z_encoder = Encoder(n_input, n_latent, n_cat_list=[n_labels], n_hidden=n_hidden, n_layers=n_layers,
                                  dropout_rate=dropout_rate)


### PR DESCRIPTION
This is related to this issue:

https://stackoverflow.com/questions/32481508/autoreload-and-package-causing-typeerror-supertype-obj-obj-must-be-an-insta

Autoreload was throwing an error when editing code and re-running a notebook cell.

This syntax for calling the parent method is simpler, legit, and solved that problem for me.

I used the regex ``\([A-Z]([^)]+), self\)`` to find all the matches in code, so this would be a comprehensive update were we to merge that change.