### PR TITLE
Classifier accuracy early stopping

### DIFF
--- a/scvi/inference/annotation.py
+++ b/scvi/inference/annotation.py
@@ -95,6 +95,8 @@ class ClassifierTrainer(Trainer):
         self.sampling_model = sampling_model
         super().__init__(*args, use_cuda=use_cuda, **kwargs)
         self.train_set, self.test_set = self.train_test(self.model, self.gene_dataset, type_class=AnnotationPosterior)
+        self.train_set.to_monitor = ['accuracy']
+        self.test_set.to_monitor = ['accuracy']
 
     @property
     def posteriors_loop(self):

--- a/scvi/inference/posterior.py
+++ b/scvi/inference/posterior.py
@@ -1,3 +1,4 @@
+from abc import abstractmethod
 import copy
 
 import numpy as np
@@ -89,6 +90,12 @@ class Posterior:
             self.data_loader_kwargs.update({'collate_fn': gene_dataset.collate_fn})
         self.data_loader_kwargs.update({'sampler': sampler})
         self.data_loader = DataLoader(gene_dataset, **self.data_loader_kwargs)
+
+    @abstractmethod
+    def accuracy(self, verbose=False):
+        pass
+
+    accuracy.mode = 'max'
 
     @property
     def indices(self):

--- a/tests/test_scvi.py
+++ b/tests/test_scvi.py
@@ -251,12 +251,11 @@ def test_nb_not_zinb():
     trainer_synthetic_svaec.train(n_epochs=1)
 
 
-
 def test_classifier_accuracy(save_path):
     cortex_dataset = CortexDataset(save_path=save_path)
     cls = Classifier(cortex_dataset.nb_genes, n_labels=cortex_dataset.n_labels)
     cls_trainer = ClassifierTrainer(cls, cortex_dataset, metrics_to_monitor=['accuracy'], frequency=1,
-                                    early_stopping_kwargs={'early_stopping_metric':'accuracy',
+                                    early_stopping_kwargs={'early_stopping_metric': 'accuracy',
                                                            'save_best_state_metric': 'accuracy'})
     cls_trainer.train(n_epochs=2)
     cls_trainer.train_set.accuracy()

--- a/tests/test_scvi.py
+++ b/tests/test_scvi.py
@@ -249,3 +249,14 @@ def test_nb_not_zinb():
                    reconstruction_loss="nb")
     trainer_synthetic_svaec = JointSemiSupervisedTrainer(svaec, synthetic_dataset, use_cuda=use_cuda)
     trainer_synthetic_svaec.train(n_epochs=1)
+
+
+
+def test_classifier_accuracy(save_path):
+    cortex_dataset = CortexDataset(save_path=save_path)
+    cls = Classifier(cortex_dataset.nb_genes, n_labels=cortex_dataset.n_labels)
+    cls_trainer = ClassifierTrainer(cls, cortex_dataset, metrics_to_monitor=['accuracy'], frequency=1,
+                                    early_stopping_kwargs={'early_stopping_metric':'accuracy',
+                                                           'save_best_state_metric': 'accuracy'})
+    cls_trainer.train(n_epochs=2)
+    cls_trainer.train_set.accuracy()


### PR DESCRIPTION
Previously, the accuracy metric couldn't be used for early stopping of training because the parent class Posterior of AnnotationPosterior didn't recognize the attribute accuracy:

`AttributeError: type object 'Posterior' has no attribute 'accuracy'
scvi/inference/trainer.py:279: AttributeError`

These modifications enable early stopping with the accuracy metric and demonstrate that it works with a test.