### PR TITLE
fix filtering operation done twice

### DIFF
--- a/scvi/dataset/dataset.py
+++ b/scvi/dataset/dataset.py
@@ -165,7 +165,7 @@ class GeneExpressionDataset(Dataset):
         Same as _filter_genes but overwrites on current dataset instead of returning data,
         and updates genes names and symbols
         """
-        self.X, subset_genes = GeneExpressionDataset._filter_genes(self, gene_names_ref, on=on)
+        _, subset_genes = GeneExpressionDataset._filter_genes(self, gene_names_ref, on=on)
         self.update_genes(subset_genes)
 
     def subsample_cells(self, size=1.):


### PR DESCRIPTION
The following raises an index error

```
from scvi.dataset import PbmcDataset

pbmc_dataset = PbmcDataset()
```

This is linked to the fact that filtering genes of attribute X of Dataset is performed twice:
- https://github.com/YosefLab/scVI/blob/master/scvi/dataset/dataset.py#L168
- https://github.com/YosefLab/scVI/blob/master/scvi/dataset/dataset.py#L169 more precisely [here](https://github.com/YosefLab/scVI/blob/master/scvi/dataset/dataset.py#L131)

This was not detected by associated (test)[https://github.com/YosefLab/scVI/blob/master/tests/test_scvi.py#L183] because it uses a reduced dataset for which genes are not really filtered `Downsampling from 10 to 10 genes` ==> downsampling does not modify the number of genes.

To solve this issue, we just modify the code such that `X` is only filtered once without changing the overall behavior of existing methods