### PR TITLE
drop support for python 3.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,6 @@ language: python
 
 python:
   - 3.7
-  - 3.6
 
 os:
   - linux

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -112,7 +112,7 @@ Before you submit a pull request, check that it meets these guidelines:
 2. If the pull request adds functionality, the docs should be updated. Put
    your new functionality into a function with a docstring, and add the
    feature to the list in README.rst.
-3. The pull request should work for Python 3.6. Check
+3. The pull request should work for Python 3.7. Check
    https://travis-ci.org/YosefLab/scVI/pull_requests
    and make sure that the tests pass for all supported Python versions.
 

--- a/README.rst
+++ b/README.rst
@@ -26,7 +26,7 @@ Single-cell Variational Inference
 Quick Start
 -----------
 
-1. Install Python 3.6 or Python 3.7. We typically use the Miniconda_ Python distribution.
+1. Install Python 3.7. We typically use the Miniconda_ Python distribution.
 
 .. _Miniconda: https://conda.io/miniconda.html
 

--- a/readthedocs.yml
+++ b/readthedocs.yml
@@ -4,5 +4,5 @@ build:
   image: latest
 
 python:
-  version: 3.6
+  version: 3.7
   setup_py_install: true

--- a/setup.py
+++ b/setup.py
@@ -48,7 +48,7 @@ setup(
         'Intended Audience :: Science/Research',
         'License :: OSI Approved :: MIT License',
         'Natural Language :: English',
-        'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
         'Operating System :: MacOS :: MacOS X',
         'Operating System :: Microsoft :: Windows',
         'Operating System :: POSIX :: Linux',

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist=py36,py37,travis
+envlist=py37,travis
 
 [testenv]
 deps=pytest
@@ -7,7 +7,7 @@ extras = test
 commands=pytest
 
 [testenv:travis]
-basepython=python3.6
+basepython=python3.7
 deps = -rrequirements.txt
 extras =
 commands =  flake8 scvi/ tests/ ./*.py


### PR DESCRIPTION
Python 3.7 is pretty mature now, and maintaining support for Python 3.6 increases the number of package-version-related issues we have to deal with. Requiring Python 3.7 should give everyone using scvi a more consistent experience.

closes #320 