### PR TITLE
modify posterior get_latent to be more consistent

### DIFF
--- a/scvi/inference/posterior.py
+++ b/scvi/inference/posterior.py
@@ -147,12 +147,8 @@ class Posterior:
         labels = []
         for tensors in self:
             sample_batch, local_l_mean, local_l_var, batch_index, label = tensors
-            if not sample:
-                if self.model.log_variational:
-                    sample_batch = torch.log(1 + sample_batch)
-                latent += [self.model.z_encoder(sample_batch)[0].cpu()]
-            else:
-                latent += [self.model.sample_from_posterior_z(sample_batch).cpu()]
+            give_mean = not sample
+            latent += [self.model.sample_from_posterior_z(sample_batch, give_mean=give_mean).cpu()]
             batch_indices += [batch_index.cpu()]
             labels += [label.cpu()]
         return np.array(torch.cat(latent)), np.array(torch.cat(batch_indices)), np.array(torch.cat(labels)).ravel()

--- a/scvi/inference/posterior.py
+++ b/scvi/inference/posterior.py
@@ -142,6 +142,11 @@ class Posterior:
 
     @torch.no_grad()
     def get_latent(self, sample=False):
+        """
+        Output posterior z mean or sample, batch index, and label
+        :param sample: z mean or z sample 
+        :return: three np.ndarrays, latent, batch_indices, labels
+        """
         latent = []
         batch_indices = []
         labels = []

--- a/scvi/inference/posterior.py
+++ b/scvi/inference/posterior.py
@@ -144,7 +144,7 @@ class Posterior:
     def get_latent(self, sample=False):
         """
         Output posterior z mean or sample, batch index, and label
-        :param sample: z mean or z sample 
+        :param sample: z mean or z sample
         :return: three np.ndarrays, latent, batch_indices, labels
         """
         latent = []


### PR DESCRIPTION
`model.sample_from_posterior_z` can already handle returning the posterior mean or a sample, so it doesn't make sense to handle this twice (once in the model, once in posterior)

resolves: #331 