### PR TITLE
Create __repr__ method for dataset

### DIFF
--- a/scvi/dataset/dataset.py
+++ b/scvi/dataset/dataset.py
@@ -98,7 +98,9 @@ class GeneExpressionDataset(Dataset):
                 if len(set_attr) == 0:
                     continue
                 descr += "\n    {}: {}".format(attr, str(list(set_attr))[1:-1])
-
+        
+        return descr
+        
     def populate_from_data(
         self,
         X: Union[np.ndarray, sp_sparse.csr_matrix],

--- a/scvi/dataset/dataset.py
+++ b/scvi/dataset/dataset.py
@@ -93,14 +93,14 @@ class GeneExpressionDataset(Dataset):
                 "cell_categorical_attribute_names",
                 "cell_measurements_columns",
             ]
-            for attr in attrs:
-                attr = getattr(self, attr)
+            for attr_name in attrs:
+                attr = getattr(self, attr_name)
                 if len(attr) == 0:
                     continue
                 if type(attr) is set:
-                    descr += "\n    {}: {}".format(attr, str(list(attr))[1:-1])
+                    descr += "\n    {}: {}".format(attr_name, str(list(attr))[1:-1])
                 else:
-                    descr += "\n    {}: {}".format(attr, str(attr))
+                    descr += "\n    {}: {}".format(attr_name, str(attr))
         
         return descr
         

--- a/scvi/dataset/dataset.py
+++ b/scvi/dataset/dataset.py
@@ -101,9 +101,9 @@ class GeneExpressionDataset(Dataset):
                     descr += "\n    {}: {}".format(attr_name, str(list(attr))[1:-1])
                 else:
                     descr += "\n    {}: {}".format(attr_name, str(attr))
-        
+
         return descr
-        
+
     def populate_from_data(
         self,
         X: Union[np.ndarray, sp_sparse.csr_matrix],

--- a/scvi/dataset/dataset.py
+++ b/scvi/dataset/dataset.py
@@ -79,6 +79,26 @@ class GeneExpressionDataset(Dataset):
         # attributes that should not be set by initilalization methods
         self.protected_attributes = ["X"]
 
+    def __repr__(self) -> str:
+        if self.X is None:
+            descr = "GeneExpressionDataset object (unpopulated)"
+        else:
+            descr = "GeneExpressionDataset object with n_cells x nb_genes = {} x {}".format(
+                self.nb_cells, self.nb_genes
+            )
+            attrs = [
+                "dataset_versions",
+                "gene_attribute_names",
+                "cell_attribute_names",
+                "cell_categorical_attribute_names",
+                "cell_measurements_columns",
+            ]
+            for attr in attrs:
+                set_attr = getattr(self, attr)
+                if len(set_attr) == 0:
+                    continue
+                descr += "\n    {}: {}".format(attr, str(list(set_attr))[1:-1])
+
     def populate_from_data(
         self,
         X: Union[np.ndarray, sp_sparse.csr_matrix],

--- a/scvi/dataset/dataset.py
+++ b/scvi/dataset/dataset.py
@@ -94,10 +94,13 @@ class GeneExpressionDataset(Dataset):
                 "cell_measurements_columns",
             ]
             for attr in attrs:
-                set_attr = getattr(self, attr)
-                if len(set_attr) == 0:
+                attr = getattr(self, attr)
+                if len(attr) == 0:
                     continue
-                descr += "\n    {}: {}".format(attr, str(list(set_attr))[1:-1])
+                if type(attr) is set:
+                    descr += "\n    {}: {}".format(attr, str(list(attr))[1:-1])
+                else:
+                    descr += "\n    {}: {}".format(attr, str(attr))
         
         return descr
         


### PR DESCRIPTION
- Adds `__repr__` method to dataset for pretty printing

Here is an example of output

```
GeneExpressionDataset object with n_cells x nb_genes = 33454 x 17009
    gene_attribute_names: 'gene_names'
    cell_attribute_names: 'labels', 'batch_indices', 'local_means', 'local_vars', 'protein_expression'
    cell_categorical_attribute_names: 'labels', 'batch_indices'
    cell_measurements_columns: {'protein_expression': 'protein_names'}
```