### PR TITLE
Fixes #419

### DIFF
--- a/scvi/dataset/dataset.py
+++ b/scvi/dataset/dataset.py
@@ -513,7 +513,7 @@ class GeneExpressionDataset(Dataset):
     #############################
 
     def __len__(self):
-        return self.X.shape[0]
+        return self.nb_cells
 
     def __getitem__(self, idx):
         """Implements @abstractcmethod in ``torch.utils.data.dataset.Dataset`` ."""

--- a/scvi/inference/posterior.py
+++ b/scvi/inference/posterior.py
@@ -118,6 +118,13 @@ class Posterior:
         else:
             return np.arange(len(self.gene_dataset))
 
+    @property
+    def nb_cells(self):
+        if hasattr(self.data_loader.sampler, "indices"):
+            return len(self.data_loader.sampler.indices)
+        else:
+            return self.gene_dataset.nb_cells
+
     def __iter__(self):
         return map(self.to_cuda, iter(self.data_loader))
 

--- a/scvi/inference/trainer.py
+++ b/scvi/inference/trainer.py
@@ -95,6 +95,9 @@ class Trainer:
 
                 for name, posterior in self._posteriors.items():
                     message = ' '.join([s.capitalize() for s in name.split('_')[-2:]])
+                    if posterior.nb_cells < 5:
+                        logging.debug(message + " is too small to track metrics (<5 samples)")
+                        continue
                     if hasattr(posterior, 'to_monitor'):
                         for metric in posterior.to_monitor:
                             if metric not in self.metrics_to_monitor:

--- a/tests/notebooks/basic_tutorial.ipynb
+++ b/tests/notebooks/basic_tutorial.ipynb
@@ -34,7 +34,8 @@
    "source": [
     "n_epochs_all = None\n",
     "save_path = 'data/'\n",
-    "show_plot = True"
+    "show_plot = True\n",
+    "test_mode = False"
    ]
   },
   {
@@ -2098,7 +2099,7 @@
     "trainer = UnsupervisedTrainer(\n",
     "    vae, \n",
     "    gene_dataset, \n",
-    "    train_size=0.9, \n",
+    "    train_size=0.9 if not test_mode else 0.5, \n",
     "    use_cuda=use_cuda,\n",
     "    frequency=5,\n",
     ")\n",

--- a/tests/notebooks/scVI_reproducibility.ipynb
+++ b/tests/notebooks/scVI_reproducibility.ipynb
@@ -2514,7 +2514,7 @@
     "\n",
     "trainer_brain_large = UnsupervisedTrainer(vae, brainlarge_dataset, frequency=1)\n",
     "\n",
-    "train_size_brain_large = 10000 if n_epochs_all is None else 2\n",
+    "train_size_brain_large = 10000 if n_epochs_all is None else 5\n",
     "trainer_brain_large.train_set = trainer_brain_large.create_posterior(indices=np.arange(train_size_brain_large))\n",
     "trainer_brain_large.test_set = trainer_brain_large.create_posterior(\n",
     "    indices=np.arange(train_size_brain_large, 2*train_size_brain_large)\n",
@@ -2894,7 +2894,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.0"
+   "version": "3.7.3"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Closes #419 
* Do not track metrics of a Posterior if it has less than 5 cells
* Add `nb_cells` attribute to Posterior, faster than `len(self.indices)`
* Remove code duplication in `GeneExpressionDataset.__len__`