### PR TITLE
Fixes around autotune's unstable behaviour

### DIFF
--- a/scvi/_settings.py
+++ b/scvi/_settings.py
@@ -4,6 +4,34 @@ from typing import Union
 logger = logging.getLogger(__name__)
 scvi_logger = logging.getLogger("scvi")
 
+autotune_formatter = logging.Formatter(
+    "[%(asctime)s - %(processName)s - %(threadName)s] %(levelname)s - %(name)s\n%(message)s"
+)
+
+
+class DispatchingFormatter(logging.Formatter):
+    """Dispatch formatter for logger and it's sub logger."""
+
+    def __init__(self, default_formatter, formatters=None):
+        super().__init__()
+        self._formatters = formatters if formatters is not None else {}
+        self._default_formatter = default_formatter
+
+    def format(self, record):
+        # Search from record's logger up to it's parents:
+        logger = logging.getLogger(record.name)
+        while logger:
+            # Check if suitable formatter for current logger exists:
+            if logger.name in self._formatters:
+                formatter = self._formatters[logger.name]
+                break
+            else:
+                logger = logger.parent
+        else:
+            # If no formatter found, just use default:
+            formatter = self._default_formatter
+        return formatter.format(record)
+
 
 def set_verbosity(level: Union[str, int]):
     """Sets logging configuration for scvi based on chosen level of verbosity.
@@ -28,6 +56,8 @@ def set_verbosity(level: Union[str, int]):
         formatter = logging.Formatter(
             "[%(asctime)s] %(levelname)s - %(name)s | %(message)s"
         )
-        ch.setFormatter(formatter)
+        ch.setFormatter(
+            DispatchingFormatter(formatter, {"scvi.autotune": autotune_formatter})
+        )
         scvi_logger.addHandler(ch)
         logger.info("Added StreamHandler with custom formatter to 'scvi' logger.")

--- a/tests/notebooks/autotune_advanced_notebook.ipynb
+++ b/tests/notebooks/autotune_advanced_notebook.ipynb
@@ -99,7 +99,8 @@
     "n_epochs = if_not_test_else(1000, 1)\n",
     "n_epochs_brain_large = if_not_test_else(50, 1)\n",
     "max_evals = if_not_test_else(100, 1)\n",
-    "reserve_timeout = if_not_test_else(180, 5)"
+    "reserve_timeout = if_not_test_else(180, 5)\n",
+    "fmin_timeout = if_not_test_else(300, 10)"
    ]
   },
   {
@@ -182,6 +183,7 @@
     "    train_func_specific_kwargs={\"n_epochs\": n_epochs},\n",
     "    max_evals=max_evals,\n",
     "    reserve_timeout=reserve_timeout,\n",
+    "    fmin_timeout=fmin_timeout,\n",
     ")"
    ]
   },
@@ -244,6 +246,7 @@
     "    train_func_specific_kwargs={\"n_epochs\": n_epochs},\n",
     "    max_evals=max_evals,\n",
     "    reserve_timeout=reserve_timeout,\n",
+    "    fmin_timeout=fmin_timeout,\n",
     ")"
    ]
   },
@@ -289,6 +292,7 @@
     "    train_func_specific_kwargs={\"n_epochs\": n_epochs},\n",
     "    max_evals=max_evals,\n",
     "    reserve_timeout=reserve_timeout,\n",
+    "    fmin_timeout=fmin_timeout,\n",
     ")"
    ]
   },
@@ -353,7 +357,7 @@
     "    exp_key=\"synthetic_dataset_scanvi\",\n",
     "    max_evals=max_evals,\n",
     "    reserve_timeout=reserve_timeout,\n",
-    "    fmin_timeout=100,\n",
+    "    fmin_timeout=fmin_timeout,\n",
     ")"
    ]
   },
@@ -401,6 +405,7 @@
     "    },\n",
     "    train_func_specific_kwargs={\"n_epochs\": n_epochs_brain_large},\n",
     "    reserve_timeout=reserve_timeout,\n",
+    "    fmin_timeout=fmin_timeout,\n",
     ")"
    ]
   },
@@ -567,6 +572,7 @@
     "    max_evals=max_evals,\n",
     "    train_func_specific_kwargs={\"n_epochs\": n_epochs},\n",
     "    reserve_timeout=reserve_timeout,\n",
+    "    fmin_timeout=fmin_timeout,\n",
     ")"
    ]
   },

--- a/tests/notebooks/basic_tutorial.ipynb
+++ b/tests/notebooks/basic_tutorial.ipynb
@@ -182,6 +182,7 @@
     "n_epochs = 1000 if n_epochs_all is None else n_epochs_all\n",
     "max_evals = 100 if n_epochs_all is None else 2\n",
     "reserve_timeout = 60 if n_epochs_all is None else 5\n",
+    "fmin_timeout = 300 if n_epochs_all is None else 10 \n",
     "\n",
     "best_trainer, trials = auto_tune_scvi_model(\n",
     "    gene_dataset=gene_dataset,\n",
@@ -190,6 +191,7 @@
     "    train_func_specific_kwargs={'n_epochs':n_epochs},\n",
     "    max_evals=max_evals,\n",
     "    reserve_timeout=reserve_timeout,\n",
+    "    fmin_timeout=fmin_timeout,\n",
     ")"
    ]
   },

--- a/tox.ini
+++ b/tox.ini
@@ -1,16 +1,16 @@
 [tox]
-envlist=py37,travis
+envlist = py37,travis
 
 [testenv]
-deps=pytest
+deps = pytest
 extras = test
-commands=pytest
+commands = pytest {posargs}
 
 [testenv:travis]
-basepython=python3.7
+basepython = python3.7
 deps = -rrequirements.txt
 extras =
-commands =  flake8 scvi/ tests/ ./*.py
-            black --check .
-            coverage run setup.py test
+commands = flake8 scvi/ tests/ ./*.py
+           black --check .
+           coverage run setup.py test
 


### PR DESCRIPTION
`auto_tune_scvi_model` was randomly failing when called multiple times with `parallel=True` because we terminated the `mongod` process but this process actually catches `SIGTERM` and does a few things before actually finishing. One of these things is to release the mongod.lock file which ensures there's only one MongoDb agent (`mongod` process) running per database. If this lock wasn't released by the time the next `auto_tune_scvi_model` lauched its Mongo agent, this agent would fail which would trigger connection errors in the workers and cause fmin to wait `fmin_timeout` after all workers have died, failing with a FminTimeoutError.

Now we wait for the `mongod` process to actually finish, additionally we test that it is actually running using `pymongo` five seconds after making the `subprocess.Popen(["mongod", ..])`.
Additionally, we output the logs of this process (originally stored in a file because verbose and messing with the autotune progress bar and logs) if the connection fails when we test it or after terminating the mongod process when behaviour is normal.

I fixed that and added a few changes which were convenient for debugging:
* let the `autotune` logs propagate all to the top so they could be caught by travis/tox
* add `{posargs}` positional argument in the first toxenv so that we can run a single test using e.g
`tox -e py37 -- tests/test_notebook.py::test_notebooks_autotune
* reduce the value of fmin_timeout in the notebooks (test mode only) so we don't have to wait too much if `auto_tune_scvi_model` fails that way

closes #438 
closes #437 