### PR TITLE
[WIP] avoid library saturation

### DIFF
--- a/scvi/models/modules.py
+++ b/scvi/models/modules.py
@@ -166,7 +166,7 @@ class Encoder(nn.Module):
             n_hidden=n_hidden,
             dropout_rate=dropout_rate,
         )
-        self.prevent_saturation = True
+        self.prevent_saturation = prevent_saturation
         self.mean_encoder = nn.Linear(n_hidden, n_output)
         self.var_encoder = nn.Linear(n_hidden, n_output)
 

--- a/scvi/models/vae.py
+++ b/scvi/models/vae.py
@@ -56,6 +56,7 @@ class VAE(nn.Module):
         dispersion: str = "gene",
         log_variational: bool = True,
         reconstruction_loss: str = "zinb",
+        prevent_library_saturation: bool = False,
     ):
         super().__init__()
         self.dispersion = dispersion
@@ -86,7 +87,12 @@ class VAE(nn.Module):
         )
         # l encoder goes from n_input-dimensional data to 1-d library size
         self.l_encoder = Encoder(
-            n_input, 1, n_layers=1, n_hidden=n_hidden, dropout_rate=dropout_rate
+            n_input,
+            1,
+            n_layers=1,
+            n_hidden=n_hidden,
+            dropout_rate=dropout_rate,
+            prevent_saturation=prevent_library_saturation,
         )
         # decoder goes from n_latent-dimensional space to n_input-d data
         self.decoder = DecoderSCVI(

--- a/scvi/models/vae.py
+++ b/scvi/models/vae.py
@@ -56,7 +56,7 @@ class VAE(nn.Module):
         dispersion: str = "gene",
         log_variational: bool = True,
         reconstruction_loss: str = "zinb",
-        prevent_library_saturation: bool = False,
+        prevent_library_saturation: bool = True,
     ):
         super().__init__()
         self.dispersion = dispersion


### PR DESCRIPTION
Hi,

I am not sure this is the way to go, but this solution allowed me to avoid getting NaNs for some model, cause by the variance of the library encoder exploding for an example. Clamping the library size directly was a bad idea in my code, I am not sure about `master`.
Anyway, do you think controlling the library could be a good idea for scVI generally speaking?