### PR TITLE
Improved error message for an incorrect `dispersion` input

### DIFF
--- a/scvi/models/vae.py
+++ b/scvi/models/vae.py
@@ -75,9 +75,11 @@ class VAE(nn.Module):
         elif self.dispersion == "gene-cell":
             pass
         else:
-            raise ValueError(f"dispersion must be one of ['gene', 'gene-batch',"
-                             f" 'gene-label', 'gene-cell'], but input was "
-                             f"{self.dispersion}")
+            raise ValueError(
+                "dispersion must be one of ['gene', 'gene-batch',"
+                " 'gene-label', 'gene-cell'], but input was "
+                "{}.format(self.dispersion)"
+            )
 
         # z encoder goes from the n_input-dimensional data to an n_latent-d
         # latent space representation

--- a/scvi/models/vae.py
+++ b/scvi/models/vae.py
@@ -72,8 +72,12 @@ class VAE(nn.Module):
             self.px_r = torch.nn.Parameter(torch.randn(n_input, n_batch))
         elif self.dispersion == "gene-label":
             self.px_r = torch.nn.Parameter(torch.randn(n_input, n_labels))
-        else:  # gene-cell
+        elif self.dispersion == "gene-cell":
             pass
+        else:
+            raise ValueError(f"dispersion must be one of ['gene', 'gene-batch',"
+                             f" 'gene-label', 'gene-cell'], but input was "
+                             f"{self.dispersion}")
 
         # z encoder goes from the n_input-dimensional data to an n_latent-d
         # latent space representation


### PR DESCRIPTION
Ensure that that input `dispersion` takes on one of the allowed values.

Due to mis-spellings and using underscores instead of hyphens, I have run into the case where I put in "gene_batch" instead of "gene-batch" on multiple occasions.  Each time, it takes me quite a while to figure out what is wrong, because the error that happens is a `TypeError` that says `torch.exp()` expects `Tensor` but is getting `NoneType` for `px_r`.

This input checking would solve the issue and help others debug.