### PR TITLE
Reclassify project as python not Jupyter notebook

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+*.py linguist-language=python
+*.ipynb linguist-documentation


### PR DESCRIPTION
Fixes an issue where GitHub thinks this project is mostly Jupyter notebooks