### PR TITLE
update Numba version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ requirements = [
     "loompy>=2.0.16",
     "tqdm>=4.31.1",
     "xlrd>=1.2.0",
-    "numba==0.45.0",  # numba 0.45.1 has a conflict with UMAP and numba 0.46.0 with parallelization in loompy
+    "numba>=0.47.0",
     "hyperopt==0.1.2",
     "anndata>=0.6.22rc1",
 ]


### PR DESCRIPTION
It appears there's some issue with the new version of scanpy and our version of numba. This numba release came out a few hours ago.