### PR TITLE
Add use_raw arg to extract_data_from_anndata

### DIFF
--- a/scvi/dataset/anndataset.py
+++ b/scvi/dataset/anndataset.py
@@ -20,6 +20,7 @@ class AnnDatasetFromAnnData(GeneExpressionDataset):
     :param batch_label: ``str`` representing AnnData obs column name for batches
     :param ctype_label: ``str`` representing AnnData obs column name for cell_types
     :param class_label: ``str`` representing AnnData obs column name for labels
+    :param use_raw: if True, copies data from .raw attribute of AnnData
     """
 
     def __init__(
@@ -28,6 +29,7 @@ class AnnDatasetFromAnnData(GeneExpressionDataset):
         batch_label: str = "batch_indices",
         ctype_label: str = "cell_types",
         class_label: str = "labels",
+        use_raw: bool = False,
     ):
         super().__init__()
         (
@@ -46,6 +48,7 @@ class AnnDatasetFromAnnData(GeneExpressionDataset):
             batch_label=batch_label,
             ctype_label=ctype_label,
             class_label=class_label,
+            use_raw=use_raw,
         )
         self.populate_from_data(
             X=X,
@@ -67,6 +70,7 @@ class DownloadableAnnDataset(DownloadableDataset):
     :param batch_label: ``str`` representing AnnData obs column name for batches
     :param ctype_label: ``str`` representing AnnData obs column name for cell_types
     :param class_label: ``str`` representing AnnData obs column name for labels
+    :param use_raw: if True, copies data from .raw attribute of AnnData
 
         Examples:
         >>> # Loading a local dataset
@@ -85,10 +89,12 @@ class DownloadableAnnDataset(DownloadableDataset):
         batch_label: str = "batch_indices",
         ctype_label: str = "cell_types",
         class_label: str = "labels",
+        use_raw: bool = False,
     ):
         self.batch_label = batch_label
         self.ctype_label = ctype_label
         self.class_label = class_label
+        self.use_raw = use_raw
         super().__init__(
             urls=url,
             filenames=filename,
@@ -119,6 +125,7 @@ class DownloadableAnnDataset(DownloadableDataset):
             batch_label=self.batch_label,
             ctype_label=self.ctype_label,
             class_label=self.class_label,
+            use_raw=self.use_raw,
         )
         self.populate_from_data(
             X=X,
@@ -135,21 +142,27 @@ def extract_data_from_anndata(
     batch_label: str = "batch_indices",
     ctype_label: str = "cell_types",
     class_label: str = "labels",
+    use_raw: bool = False,
 ):
     data, labels, batch_indices, gene_names, cell_types = None, None, None, None, None
 
+    if use_raw:
+        counts = ad.raw.X
+    else:
+        counts = ad.X
+
     # treat all possible cases according to anndata doc
-    if isinstance(ad.X, np.ndarray):
-        data = ad.X.copy()
-    if isinstance(ad.X, pd.DataFrame):
-        data = ad.X.values
-    if isinstance(ad.X, csr_matrix):
+    if isinstance(counts, np.ndarray):
+        data = counts.copy()
+    if isinstance(counts, pd.DataFrame):
+        data = counts.values
+    if isinstance(counts, csr_matrix):
         # keep sparsity above 1 Gb in dense form
-        if reduce(operator.mul, ad.X.shape) * ad.X.dtype.itemsize < 1e9:
+        if reduce(operator.mul, counts.shape) * counts.dtype.itemsize < 1e9:
             logger.info("Dense size under 1Gb, casting to dense format (np.ndarray).")
-            data = ad.X.toarray()
+            data = counts.toarray()
         else:
-            data = ad.X.copy()
+            data = counts.copy()
 
     gene_names = np.asarray(ad.var.index.values, dtype=str)
 

--- a/tests/dataset/test_anndataset.py
+++ b/tests/dataset/test_anndataset.py
@@ -24,3 +24,10 @@ class TestAnnDataset(TestCase):
     def test_populate_and_train_one(self):
         dataset = DownloadableAnnDataset("TM_droplet_mat.h5ad", save_path="tests/data")
         unsupervised_training_one_epoch(dataset)
+
+    def test_use_raw_flag(self):
+        raw_data = np.random.randint(1, 5, size=(4, 7))
+        ad = anndata.AnnData(raw_data)
+        ad.raw = ad.copy()
+        dataset = AnnDatasetFromAnnData(ad, use_raw=True)
+        np.testing.assert_array_equal(dataset.X, raw_data)


### PR DESCRIPTION
When `use_raw` is True, `extract_data_from_anndata()` copies the data from the `.raw.X` attribute of anndata instead of `.X`
