### PR TITLE
 handling gene attribute and cell attribute of the same name

### DIFF
--- a/scvi/dataset/dataset.py
+++ b/scvi/dataset/dataset.py
@@ -669,7 +669,7 @@ class GeneExpressionDataset(Dataset):
         if (attribute_name in self.protected_attributes) or (attribute_name in self.gene_attribute_names):
             valid_attribute_name = attribute_name + "_cell"
             logger.warning(
-                "{} is a protected attribute or already exist as a gene attribute and cannot be set with this name "
+                "{} is a protected attribute or already exists as a gene attribute and cannot be set with this name "
                 "in initialize_cell_attribute, changing name to {} and setting".format(
                     attribute_name, valid_attribute_name
                 )
@@ -718,7 +718,7 @@ class GeneExpressionDataset(Dataset):
         if (attribute_name in self.protected_attributes) or (attribute_name in self.cell_attribute_names):
             valid_attribute_name = attribute_name + "_gene"
             logger.warning(
-                "{} is a protected attribute or already exist as a cell attribute and cannot be set with this name "
+                "{} is a protected attribute or already exists as a cell attribute and cannot be set with this name "
                 "in initialize_gene_attribute, changing name to {} and setting".format(
                     attribute_name, valid_attribute_name
                 )

--- a/scvi/dataset/dataset.py
+++ b/scvi/dataset/dataset.py
@@ -666,10 +666,10 @@ class GeneExpressionDataset(Dataset):
 
     def initialize_cell_attribute(self, attribute_name, attribute, categorical=False):
         """Sets and registers a cell-wise attribute, e.g annotation information."""
-        if attribute_name in self.protected_attributes:
+        if (attribute_name in self.protected_attributes) or (attribute_name in self.gene_attribute_names):
             valid_attribute_name = attribute_name + "_cell"
             logger.warning(
-                "{} is a protected attribute and cannot be set with this name "
+                "{} is a protected attribute or already exist as a gene attribute and cannot be set with this name "
                 "in initialize_cell_attribute, changing name to {} and setting".format(
                     attribute_name, valid_attribute_name
                 )
@@ -715,11 +715,11 @@ class GeneExpressionDataset(Dataset):
 
     def initialize_gene_attribute(self, attribute_name, attribute):
         """Sets and registers a gene-wise attribute, e.g annotation information."""
-        if attribute_name in self.protected_attributes:
+        if (attribute_name in self.protected_attributes) or (attribute_name in self.cell_attribute_names):
             valid_attribute_name = attribute_name + "_gene"
             logger.warning(
-                "{} is a protected attribute and cannot be set with this name "
-                "in initialize_cell_attribute, changing name to {} and setting".format(
+                "{} is a protected attribute or already exist as a cell attribute and cannot be set with this name "
+                "in initialize_gene_attribute, changing name to {} and setting".format(
                     attribute_name, valid_attribute_name
                 )
             )


### PR DESCRIPTION
this is relevant to the previous issue I mentioned about handling gene attribute and cell attribute of the same name in **populate_from_data**.
basically I made a small change to **initialize_gene_attribute** and **initialize_cell_attribute** to not only check for conflict with existing **protected_attributes**, but also conflict with existing cell/gene attributes and append _cell or _gene accordingly.
Let me know whether additional changes should be made. 