### PR TITLE
fix adata storage issue when saving and loading posteriors

### DIFF
--- a/scvi/dataset/anndataset.py
+++ b/scvi/dataset/anndataset.py
@@ -65,7 +65,7 @@ class AnnDatasetFromAnnData(GeneExpressionDataset):
         Ys = []
         if cell_measurements_col_mappings is not None:
             for name, attr_name in cell_measurements_col_mappings.items():
-                columns = uns[name]
+                columns = uns[attr_name]
                 measurement = CellMeasurement(
                     name=name,
                     data=obsm[name],

--- a/scvi/dataset/dataset.py
+++ b/scvi/dataset/dataset.py
@@ -1285,7 +1285,8 @@ class GeneExpressionDataset(Dataset):
 
         # It's important to save the measurements name mapping for latter loading
         all_names = {
-            name: getattr(self, name) for name in self.cell_measurements_col_mappings
+            attr_name: getattr(self, attr_name)
+            for _, attr_name in self.cell_measurements_col_mappings.items()
         }
         uns = dict(
             cell_measurements_col_mappings=self.cell_measurements_col_mappings,

--- a/tests/test_scvi.py
+++ b/tests/test_scvi.py
@@ -508,7 +508,7 @@ def test_totalvi(save_path):
         new_post = load_posterior(
             posterior_save_path, model=new_totalvae, use_cuda=False
         )
-        assert hasattr(new_post, "protein_names")
+        assert hasattr(new_post.gene_dataset, "protein_names")
         assert new_post.posterior_type == "TotalPosterior"
         assert np.array_equal(
             new_post.gene_dataset.protein_expression, dataset.protein_expression

--- a/tests/test_scvi.py
+++ b/tests/test_scvi.py
@@ -508,6 +508,7 @@ def test_totalvi(save_path):
         new_post = load_posterior(
             posterior_save_path, model=new_totalvae, use_cuda=False
         )
+        assert hasattr(new_post, "protein_names")
         assert new_post.posterior_type == "TotalPosterior"
         assert np.array_equal(
             new_post.gene_dataset.protein_expression, dataset.protein_expression


### PR DESCRIPTION
the anndataset saver was saving the data values instead of the column names and the loader was looking for the values in uns instead of the column names 