### PR TITLE
Set default save_path_10X to "data/"

### DIFF
--- a/scvi/dataset/dataset10X.py
+++ b/scvi/dataset/dataset10X.py
@@ -297,7 +297,7 @@ class BrainSmallDataset(Dataset10X):
     def __init__(
         self,
         save_path: str = "data/",
-        save_path_10X: str = None,
+        save_path_10X: str = "data/",
         delayed_populating: bool = False,
         remove_extracted_data: bool = False,
     ):


### PR DESCRIPTION
`gene_dataset = BrainSmallDataset()` throws the following exception because save_path_10X is not set by default:

```pytb
---------------------------------------------------------------------------
TypeError                                 Traceback (most recent call last)
<ipython-input-9-7fe29d288c3b> in <module>
      1 get_ipython().run_line_magic('pdb', '')
      2 
----> 3 dset = BrainSmallDataset()

~/.anaconda3/lib/python3.7/site-packages/scvi/dataset/dataset10X.py in __init__(self, save_path, save_path_10X, delayed_populating, remove_extracted_data)
    306             save_path=save_path_10X,
    307             remove_extracted_data=remove_extracted_data,
--> 308             delayed_populating=delayed_populating,
    309         )
    310         _download(

~/.anaconda3/lib/python3.7/site-packages/scvi/dataset/dataset10X.py in __init__(self, dataset_name, filename, save_path, url, type, dense, measurement_names_column, remove_extracted_data, delayed_populating)
    135             filename_skeleton = group_to_filename_skeleton[group]
    136             filename = filename_skeleton.format(type)
--> 137             save_path = os.path.join(save_path, dataset_name)
    138         elif filename is not None and url is not None:
    139             logger.debug("Loading 10X dataset with custom url and filename")

~/.anaconda3/lib/python3.7/posixpath.py in join(a, *p)
     78     will be discarded.  An empty last part will result in a path that
     79     ends with a separator."""
---> 80     a = os.fspath(a)
     81     sep = _get_sep(a)
     82     path = a

TypeError: expected str, bytes or os.PathLike object, not NoneType
```

setting it to `data/` by default would make `gene_dataset = BrainSmallDataset()` code work.