### PR TITLE
fix pbmcdataset download

### DIFF
--- a/scvi/dataset/dataset.py
+++ b/scvi/dataset/dataset.py
@@ -1,5 +1,6 @@
 from abc import abstractmethod, ABC
 from collections import OrderedDict, defaultdict
+from urllib.error import HTTPError
 import copy
 from dataclasses import dataclass
 from functools import partial
@@ -2037,8 +2038,11 @@ def _download(url: str, save_path: str, filename: str):
     if os.path.exists(os.path.join(save_path, filename)):
         logger.info("File %s already downloaded" % (os.path.join(save_path, filename)))
         return
-
-    r = urllib.request.urlopen(url)
+    try:
+        r = urllib.request.urlopen(url)
+    except HTTPError:
+        req = urllib.request.Request(url, headers={"User-Agent": "Magic Browser"})
+        r = urllib.request.urlopen(req)
     logger.info("Downloading file at %s" % os.path.join(save_path, filename))
 
     def read_iter(file, block_size=1000):


### PR DESCRIPTION
Fixes #706 

Seems like 10X requires us to spoof as a browser when downloading data for PbmcDataset. Specifically this file: http://cf.10xgenomics.com/samples/cell-exp/2.1.0/pbmc8k/pbmc8k_filtered_gene_bc_matrices.tar.gz

Solution from: 
https://stackoverflow.com/questions/3336549/pythons-urllib2-why-do-i-get-error-403-when-i-urlopen-a-wikipedia-page