### PR TITLE
Make loompy optional, raise sckmisc import error

### DIFF
--- a/scvi/dataset/dataset.py
+++ b/scvi/dataset/dataset.py
@@ -1770,7 +1770,13 @@ def seurat_v3_highly_variable_genes(
     """
 
     from scanpy.preprocessing._utils import _get_mean_var
-    from skmisc.loess import loess
+
+    try:
+        from skmisc.loess import loess
+    except ImportError:
+        raise ImportError(
+            "Please install skmisc package via `pip install --user scikit-misc"
+        )
 
     if batch_key is None:
         batch_info = pd.Categorical(np.zeros(adata.shape[0], dtype=int))

--- a/scvi/dataset/loom.py
+++ b/scvi/dataset/loom.py
@@ -2,7 +2,6 @@ import logging
 import os
 from typing import List, Optional
 
-import loompy
 import numpy as np
 
 from scvi.dataset.dataset import DownloadableDataset
@@ -78,6 +77,13 @@ class LoomDataset(DownloadableDataset):
             gene_attributes_dict,
             global_attributes_dict,
         ) = (None, None, None, None, None, None, None)
+
+        try:
+            import loompy
+        except ImportError:
+            raise ImportError(
+                "Please install loompy package via `pip install --user loompy"
+            )
 
         ds = loompy.connect(os.path.join(self.save_path, self.filenames[0]))
         select = ds[:, :].sum(axis=0) > 0  # Take out cells that don't express any gene

--- a/scvi/dataset/smfish.py
+++ b/scvi/dataset/smfish.py
@@ -1,7 +1,6 @@
 import logging
 import os
 
-import loompy
 import numpy as np
 
 from scvi.dataset.dataset import DownloadableDataset
@@ -40,6 +39,12 @@ class SmfishDataset(DownloadableDataset):
         )
 
     def populate(self):
+        try:
+            import loompy
+        except ImportError:
+            raise ImportError(
+                "Please install loompy package via `pip install --user loompy"
+            )
         logger.info("Loading smFISH dataset")
         ds = loompy.connect(os.path.join(self.save_path, self.filenames[0]))
         gene_names = ds.ra["Gene"].astype(np.str)

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ requirements = [
     "anndata>=0.7",
     "scanpy>=1.4.6",
     'dataclasses; python_version < "3.7"',  # for `dataclass`
-    "scikit-misc",
+    "scikit-misc>=0.1.3",
 ]
 
 setup_requirements = ["pip>=18.1"]

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,6 @@ requirements = [
     "scikit-learn>=0.20.3",
     "h5py>=2.9.0",
     "pandas>=0.25",
-    "loompy>=3.0.6",
     "tqdm>=4.31.1",
     "xlrd>=1.2.0",
     "hyperopt==0.1.2",
@@ -50,6 +49,7 @@ extras_requirements = {
         "umap-learn>=0.3.10",
         "seaborn>=0.9.0",
         "leidenalg>=0.7.0",
+        "loompy>=3.0.6",
     ],
     "docs": [
         "sphinx>=2.0.1",


### PR DESCRIPTION
- Fixes #715 

loompy takes a bit of time to import and is not necessary to run scvi except for a few built in datasets; therefore, I'm proposing to make it an optional dependency.